### PR TITLE
Fix regression in Tree List culling

### DIFF
--- a/ui/tree-list.mod/tree-list.js
+++ b/ui/tree-list.mod/tree-list.js
@@ -335,7 +335,7 @@ var TreeList = exports.TreeList = Component.specialize(/** @lends TreeList.proto
             }
 
             window.addEventListener("resize", this, false);
-            this._element.addEventListener("scroll", this, false);
+            this._treeListWrapper.addEventListener("scroll", this, false);
             this._startListeningToTranslateIfNeeded();
             this.handleScroll();
             this.handleTreeChange();
@@ -634,7 +634,7 @@ var TreeList = exports.TreeList = Component.specialize(/** @lends TreeList.proto
             var startRow, height, endRow, index;
             if (typeof this.rowHeight === "function") {
                 index = 0;
-                height = this._element.scrollTop;
+                height = this._treeListWrapper.scrollTop;
                 while (this._rowTopMargins[index + 1] < height) {
                     index++;
                 }
@@ -645,7 +645,7 @@ var TreeList = exports.TreeList = Component.specialize(/** @lends TreeList.proto
                 }
                 endRow = index;
             } else {
-                startRow = this._element.scrollTop / this._rowHeight;
+                startRow = this._treeListWrapper.scrollTop / this._rowHeight;
                 height = window.innerHeight / this._rowHeight;
                 endRow = startRow + height;
             }


### PR DESCRIPTION
A wrapper element added to Tree List introduced a regression multiple years ago. Scroll was moved from the main element to the wrapper element, but the listening for the scroll element was nor properly updated, causing content culling issues (hidden content at the end of long trees).

This fixes the issue by switching the listening to scroll events and the reading of the scrollTop values to the wrapper element.