### PR TITLE
Fix failing HttpService test

### DIFF
--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -860,7 +860,7 @@ DataService.addClassProperties({
 
             if(jObjectDescriptor.object) {
                 this._constructorToObjectDescriptorMap.set(jObjectDescriptor.object, jObjectDescriptor);
-            } else if(jObjectDescriptor.module) {
+            } else if(jObjectDescriptor.module && typeof jObjectDescriptor.loadObjectFromModule === "function") {
                 var self = this;
                 result = jObjectDescriptor.loadObjectFromModule()
                     .then(function() {
@@ -943,7 +943,7 @@ DataService.addClassProperties({
             } else {
                 var self = this,
                 module = objectDescriptor.module;
-                if(module) {
+                if(module && typeof objectDescriptor.loadObjectFromModule === "function") {
                     return objectDescriptor.loadObjectFromModule().then(function (moduleObject) {
                         return self.__makePrototypeForType(childService, objectDescriptor, moduleObject);
                     });


### PR DESCRIPTION
The code in Data Service was assuming that any
ObjectDescriptor with a module has the
loadObjectFromModule method from the
ModuleObjectDescriptor. However the failing tests
prove that this is not necessarily true.

It is debatable if the test is correct or not, and if non ModuleObjectDescriptors should have modules
or not, but I feel that the checks I'm adding can not hurt, so I feel this is a reasonable fix.