### PR TITLE
Improvements and fixes with Check Control components

### DIFF
--- a/ui/button.mod/button.css
+++ b/ui/button.mod/button.css
@@ -41,25 +41,34 @@
      * FIXME: Hide temporally empty elements wait for this pr to be merged: 
      * https://github.com/PhrontHQ/mod/pull/37 
      */
-    > div:empty {
+    >div:empty {
         display: none;
     }
 
     /* Visual Specifications */
 
-    > .ModButton-visual {
+    >.ModButton-visual {
         position: relative;
     }
 
-    > svg.ModButton-visual {
+    >svg.ModButton-visual {
         fill: currentColor;
     }
 
-    /* Pending State */
+    /* States */
 
+    &.mod--disabled,
     &.mod--pending {
         pointer-events: none;
+    }
+
+    &.mod--pending {
         /* FIXME: Temporary arbitrary values, waiting for Button Themes */
         opacity: 0.75;
+    }
+
+    &.mod--disabled {
+        /* FIXME: Temporary arbitrary values, waiting for Button Themes */
+        opacity: 0.5;
     }
 }

--- a/ui/check-control.js
+++ b/ui/check-control.js
@@ -5,6 +5,7 @@
  */
 const { PressComposer } = require("composer/press-composer");
 const { Control } = require("ui/control");
+const { Montage } = require("core/core");
 
 /**
  * The base class for the Checkbox component. You will not typically create

--- a/ui/check-control.js
+++ b/ui/check-control.js
@@ -1,188 +1,165 @@
 /*global require, exports */
 
 /**
-    @module mod/ui/check-control
-*/
-var Control = require("ui/control").Control,
-    PressComposer = require("composer/press-composer").PressComposer;
+ *   @module mod/ui/check-control
+ */
+const { PressComposer } = require("composer/press-composer");
+const { Control } = require("ui/control");
 
 /**
-    The base class for the Checkbox component. You will not typically create this class directly but instead use the Checkbox component.
-    @class module:mod/ui/check-input.CheckControl
-    @extends module:mod/ui/control.Control
-*/
-exports.CheckControl =  Control.specialize({
-    constructor: {
-        value: function CheckControl() {
-
-            this.defineBindings({
-                "classList.has('montage--checked')": {
-                     "<-": "checked"
-                }
-            });
-
-            var leftExpression = "classList.has('",
-                bindings = {};
-            leftExpression += this.checkedClassName;
-            leftExpression += "')";
-            bindings[leftExpression] = {
-                    "<-": "checked"
-            };
-
-            this.defineBindings(bindings);
-        }
-    },
-
-    // HTMLInputElement methods
-
-    // click() deliberately omitted, use checked = instead
-
-    // Callbacks
-    draw: {
-        value: function() {
-            this.super();
-            this._element.setAttribute("aria-checked", this._checked);
-        }
-    },
-
-    _pressComposer: {
-        enumerable: false,
-        value: null
-    },
-
-    prepareForActivationEvents: {
-        value: function() {
-            var pressComposer = this._pressComposer = new PressComposer();
-            this.addComposer(pressComposer);
-            pressComposer.addEventListener("pressStart", this, false);
-            pressComposer.addEventListener("press", this, false);
-            pressComposer.addEventListener("cancel", this, false);
-            this._element.addEventListener('change', this);
-        }
-    },
-
-    toggleChecked: {
-        value: function () {
-            if (this.disabled) {
-                return;
-            }
-            this.checked = !this.checked;
-            this.dispatchActionEvent();
-        }
-    },
+ * The base class for the Checkbox component. You will not typically create
+ * this class directly but instead use the Checkbox component.
+ * @class module:mod/ui/check-input.CheckControl
+ * @extends module:mod/ui/control.Control
+ */
+exports.CheckControl = class CheckControl extends Control {
+    // <---- Properties ---->
 
     /**
-    Fake the checking of the element.
+     * Stores if we need to "fake" checking of the input element.
+     *
+     * When preventDefault is called on touchstart and touchend events (e.g. by
+     * the scroller component) the checkbox doesn't check itself, so we need
+     * to fake it later.
+     *
+     * @default false
+     * @private
+     */
+    _shouldFakeCheck = false;
 
-    Changes the checked property of the element and dispatches a change event.
-    Radio button overrides this.
+    _pressComposer = null;
 
-    @private
-    */
-    _fakeCheck: {
-        enumerable: false,
-        value: function() {
-            var changeEvent;
-            // NOTE: this may be BAD, modifying the element outside of
-            // the draw loop, but it's what a click/touch would
-            // actually have done
-            this._element.checked = !this._element.checked;
-            changeEvent = document.createEvent("HTMLEvents");
-            changeEvent.initEvent("change", true, true);
-            this._element.dispatchEvent(changeEvent);
-        }
-    },
+    checkedClassName = null;
 
-    /**
-    Stores if we need to "fake" checking of the input element.
+    constructor() {
+        super();
+        this.defineBindings({
+            "classList.has('montage--checked')": {
+                "<-": "checked",
+            },
+        });
 
-    When preventDefault is called on touchstart and touchend events (e.g. by
-    the scroller component) the checkbox doesn't check itself, so we need
-    to fake it later.
+        var leftExpression = "classList.has('",
+            bindings = {};
+        leftExpression += this.checkedClassName;
+        leftExpression += "')";
+        bindings[leftExpression] = {
+            "<-": "checked",
+        };
 
-    @default false
-    @private
-    */
-    _shouldFakeCheck: {
-        enumerable: false,
-        value: false
-    },
+        this.defineBindings(bindings);
+    }
 
-    // Handlers
+    // <---- Public Functions ---->
 
-    handlePressStart: {
-        value: function(event) {
-            if (this.hasStandardElement){
-                this._shouldFakeCheck = event.defaultPrevented;
-            }
-            else {
-                this.active = true;
+    toggleChecked() {
+        if (this.disabled) return;
 
-                if (event.touch) {
-                    // Prevent default on touchmove so that if we are inside a scroller,
-                    // it scrolls and not the webpage
-                    document.addEventListener("touchmove", this, false);
-                }
-            }
+        this.checked = !this.checked;
+        this.dispatchActionEvent();
+    }
 
-        }
-    },
+    // <---- Event Handlers ---->
 
+    handlePressStart(event) {
+        if (this.hasStandardElement) {
+            this._shouldFakeCheck = event.defaultPrevented;
+        } else {
+            this.active = true;
 
-    handlePress: {
-        value: function(event) {
-            if (this._shouldFakeCheck) {
-                this._shouldFakeCheck = false;
-                this._fakeCheck();
-            }
-
-            if (!this.hasStandardElement) {
-                this.active = false;
-                this.toggleChecked();
-
-            }
-
-        }
-    },
-
-    handlePressCancel: {
-        value: function (/* event */) {
-            if (!this.hasStandardElement) {
-                this.active = false;
-                document.removeEventListener("touchmove", this, false);
-            }
-        }
-    },
-
-    handleChange: {
-        enumerable: false,
-        value: function(event) {
-            if (!this._pressComposer || this._pressComposer.state !== PressComposer.CANCELLED) {
-                Object.getPropertyDescriptor(this, "checked").set.call(this,
-                    this.element.checked, true);
-                this.dispatchActionEvent();
+            if (event.touch) {
+                // Prevent default on touchmove so that if we are inside a scroller,
+                // it scrolls and not the webpage
+                document.addEventListener("touchmove", this, false);
             }
         }
     }
+
+    handlePress(_) {
+        if (this._shouldFakeCheck) {
+            this._shouldFakeCheck = false;
+            this._fakeCheck();
+        }
+
+        if (!this.hasStandardElement) {
+            this.active = false;
+            this.toggleChecked();
+        }
+    }
+
+    handlePressCancel(_) {
+        if (!this.hasStandardElement) {
+            this.active = false;
+            document.removeEventListener("touchmove", this, false);
+        }
+    }
+
+    handleChange(_) {
+        if (!this._pressComposer || this._pressComposer.state !== PressComposer.CANCELLED) {
+            Object.getPropertyDescriptor(this, "checked").set.call(this, this.element.checked, true);
+            this.dispatchActionEvent();
+        }
+    }
+
+    // <---- Lifecycle Functions ---->
+
+    /**
+     * Prepares the component for activation events.
+     * @override
+     * @protected
+     */
+    prepareForActivationEvents() {
+        this._pressComposer = new PressComposer();
+        this.addComposer(this._pressComposer);
+
+        this._pressComposer.addEventListener("pressStart", this, false);
+        this._pressComposer.addEventListener("press", this, false);
+        this._pressComposer.addEventListener("cancel", this, false);
+        this._element.addEventListener("change", this);
+    }
+
+    draw() {
+        super.draw();
+        this._element.setAttribute("aria-checked", this._checked);
+    }
+
+    // <---- Private Functions ---->
+
+
+
+    /**
+     * Fake the checking of the element.
+     *
+     * Changes the checked property of the element and dispatches a change event.
+     * Radio button overrides this.
+     *
+     * @private
+     */
+    _fakeCheck() {
+        // NOTE: this may be BAD, modifying the element outside of
+        // the draw loop, but it's what a click/touch would
+        // actually have done
+        this._element.checked = !this._element.checked;
+        changeEvent = document.createEvent("HTMLEvents");
+        changeEvent.initEvent("change", true, true);
+        this._element.dispatchEvent(changeEvent);
+    }
+};
+
+exports.CheckControl.addAttributes({
+    /** @lends module:"mod/ui/native/check-control".InputCheckbox# */
+
+    /**
+     * Specifies if the checkbox is in it checked state or not.
+     * @type {boolean}
+     * @default false
+     */
+    checked: { value: false, dataType: "boolean" },
+
+    /**
+     * The value associated with the element.
+     * @type {string}
+     * @default "on"
+     */
+    value: { value: "on" },
 });
-
-exports.CheckControl.addAttributes( /** @lends module:"mod/ui/native/check-control".InputCheckbox# */ {
-
-
-/**
-    Specifies if the checkbox is in it checked state or not.
-    @type {boolean}
-    @default false
-*/
-    checked: {value: false, dataType: 'boolean'},
-
-/**
-    The value associated with the element.
-    @type {string}
-    @default "on"
-*/
-    value: {value: 'on'}
-
-
-});
-

--- a/ui/check-control.js
+++ b/ui/check-control.js
@@ -13,23 +13,23 @@ const { Control } = require("ui/control");
  * @extends module:mod/ui/control.Control
  */
 exports.CheckControl = class CheckControl extends Control {
-    // <---- Properties ---->
-
-    /**
-     * Stores if we need to "fake" checking of the input element.
-     *
-     * When preventDefault is called on touchstart and touchend events (e.g. by
-     * the scroller component) the checkbox doesn't check itself, so we need
-     * to fake it later.
-     *
-     * @default false
-     * @private
-     */
-    _shouldFakeCheck = false;
-
-    _pressComposer = null;
-
-    checkedClassName = null;
+    static {
+        Montage.defineProperties(this.prototype, {
+            /**
+             * Stores if we need to "fake" checking of the input element.
+             *
+             * When preventDefault is called on touchstart and touchend events (e.g. by
+             * the scroller component) the checkbox doesn't check itself, so we need
+             * to fake it later.
+             *
+             * @default false
+             * @private
+             */
+            _shouldFakeCheck: { value: false },
+            _pressComposer: { value: null },
+            checkedClassName: { value: null },
+        });
+    }
 
     constructor() {
         super();

--- a/ui/check-control.js
+++ b/ui/check-control.js
@@ -33,19 +33,15 @@ exports.CheckControl = class CheckControl extends Control {
 
     constructor() {
         super();
-        this.defineBindings({
-            "classList.has('montage--checked')": {
-                "<-": "checked",
-            },
-        });
+        const bindings = {};
 
-        var leftExpression = "classList.has('",
-            bindings = {};
-        leftExpression += this.checkedClassName;
-        leftExpression += "')";
-        bindings[leftExpression] = {
-            "<-": "checked",
-        };
+        // Add default binding
+        this._addCheckedClassNameToBindings("montage--checked", bindings);
+
+        // Add custom binding if a custom class name is provided
+        if (this.checkedClassName) {
+            this._addCheckedClassNameToBindings(this.checkedClassName, bindings);
+        }
 
         this.defineBindings(bindings);
     }
@@ -125,7 +121,15 @@ exports.CheckControl = class CheckControl extends Control {
 
     // <---- Private Functions ---->
 
+    /**
+     * @private
+     */
+    _addCheckedClassNameToBindings(className, bindings = {}) {
+        const expression = `classList.has('${className}')`;
+        bindings[expression] = { "<-": "checked" };
 
+        return bindings;
+    }
 
     /**
      * Fake the checking of the element.

--- a/ui/check-control.js
+++ b/ui/check-control.js
@@ -36,6 +36,9 @@ exports.CheckControl = class CheckControl extends Control {
         const bindings = {};
 
         // Add default binding
+        this._addCheckedClassNameToBindings("mod--checked", bindings);
+
+        // TODO: deprecated
         this._addCheckedClassNameToBindings("montage--checked", bindings);
 
         // Add custom binding if a custom class name is provided

--- a/ui/check-control.js
+++ b/ui/check-control.js
@@ -140,8 +140,12 @@ exports.CheckControl = class CheckControl extends Control {
         // the draw loop, but it's what a click/touch would
         // actually have done
         this._element.checked = !this._element.checked;
-        changeEvent = document.createEvent("HTMLEvents");
-        changeEvent.initEvent("change", true, true);
+
+        const changeEvent = new Event("change", {
+            cancelable: true,
+            bubbles: true,
+        });
+
         this._element.dispatchEvent(changeEvent);
     }
 };

--- a/ui/checkbox.mod/checkbox.js
+++ b/ui/checkbox.mod/checkbox.js
@@ -3,6 +3,7 @@
  * @requires mod/ui/check-control
  */
 const { CheckControl } = require("ui/check-control");
+const { Montage } = require("core/core");
 
 /**
  *  @class module:"mod/ui/native/checkbox.mod".Checkbox

--- a/ui/checkbox.mod/checkbox.js
+++ b/ui/checkbox.mod/checkbox.js
@@ -1,26 +1,23 @@
 /**
-    @module "mod/ui/native/checkbox.mod"
-    @requires mod/core/core
-    @requires mod/ui/check-control
-*/
-var CheckControl = require("ui/check-control").CheckControl;
+ * @module "mod/ui/native/checkbox.mod"
+ * @requires mod/ui/check-control
+ */
+const { CheckControl } = require("ui/check-control");
 
 /**
+ *  @class module:"mod/ui/native/checkbox.mod".Checkbox
+ *  @extends module:mod/ui/check-control.CheckControl
+ */
+exports.Checkbox = class Checkbox extends CheckControl {
+    // <---- Properties ---->
 
-    @class module:"mod/ui/native/checkbox.mod".Checkbox
-    @extends module:mod/ui/check-control.CheckControl
-*/
-var Checkbox = exports.Checkbox = CheckControl.specialize({
-    enterDocument: {
-        value: function (firstTime) {
-            this.super(firstTime);
-            if (firstTime) {
-                this.element.setAttribute("role", "checkbox");
-            }
+    hasTemplate = false;
+
+    // <---- Lifecycle Functions ---->
+
+    enterDocument(firstTime) {
+        if (firstTime) {
+            this.element.setAttribute("role", "checkbox");
         }
-    },
-
-    hasTemplate: {
-        value: false
     }
-});
+};

--- a/ui/checkbox.mod/checkbox.js
+++ b/ui/checkbox.mod/checkbox.js
@@ -9,9 +9,11 @@ const { CheckControl } = require("ui/check-control");
  *  @extends module:mod/ui/check-control.CheckControl
  */
 exports.Checkbox = class Checkbox extends CheckControl {
-    // <---- Properties ---->
-
-    hasTemplate = false;
+    static {
+        Montage.defineProperties(this.prototype, {
+            hasTemplate: { value: false }
+        });
+    }
 
     // <---- Lifecycle Functions ---->
 

--- a/ui/checkbox.mod/teach/ui/main.mod/main.css
+++ b/ui/checkbox.mod/teach/ui/main.mod/main.css
@@ -60,7 +60,7 @@ header {
     fill: transparent;
 }
 
-.checkbox.custom.montage--checked .CheckboxCustom-icon {
+.checkbox.custom.mod--checked .CheckboxCustom-icon {
     fill: inherit;
 }
 
@@ -83,7 +83,7 @@ header {
 }
 
 .checkbox.custom.mod--active,
-.checkbox.custom.montage--checked {
+.checkbox.custom.mod--checked {
     border-color: hsla(0,0%,70%,1);
     background-image: -webkit-linear-gradient(top, hsl(0,0%,90%), hsl(0,0%,86%) );
     background-image: -moz-linear-gradient(top, hsl(0,0%,90%), hsl(0,0%,86%) );

--- a/ui/checkbox.mod/teach/ui/main.mod/main.js
+++ b/ui/checkbox.mod/teach/ui/main.mod/main.js
@@ -1,4 +1,4 @@
-var Component = require("mod/ui/component").Component;
+const { Component } = require("mod/ui/component");
 
 exports.Main = class Main extends Component /** @lends Main# */ {
 

--- a/ui/condition.mod/teach/ui/main.mod/main.css
+++ b/ui/condition.mod/teach/ui/main.mod/main.css
@@ -60,7 +60,7 @@ header {
     fill: transparent;
 }
 
-.checkbox.custom.montage--checked .CheckboxCustom-icon {
+.checkbox.custom.mod--checked .CheckboxCustom-icon {
     fill: inherit;
 }
 
@@ -83,7 +83,7 @@ header {
 }
 
 .checkbox.custom.mod--active,
-.checkbox.custom.montage--checked {
+.checkbox.custom.mod--checked {
     border-color: hsla(0,0%,70%,1);
     background-image: -webkit-linear-gradient(top, hsl(0,0%,90%), hsl(0,0%,86%) );
     background-image: -moz-linear-gradient(top, hsl(0,0%,90%), hsl(0,0%,86%) );

--- a/ui/radio.mod/radio.js
+++ b/ui/radio.mod/radio.js
@@ -1,95 +1,79 @@
 /**
-    @module "mod/ui/input-radio.mod"
-*/
-var CheckControl = require("ui/check-control").CheckControl,
-    PressComposer = require("../../composer/press-composer").PressComposer,
-    KeyComposer = require("../../composer/key-composer").KeyComposer;
+ *   @module "mod/ui/input-radio.mod"
+ */
+const { KeyComposer } = require("../../composer/key-composer");
+const { CheckControl } = require("ui/check-control");
+
 /**
  * Wraps the a &lt;input type="radio"> element with binding support for the element's standard attributes.
-   @class module:"mod/ui/native/input-radio.mod".InputRadio
-   @extends module:mod/ui/check-input.CheckInput
+ * @class module:"mod/ui/native/input-radio.mod".InputRadio
+ * @extends module:mod/ui/check-input.CheckInput
  */
-exports.Radio = CheckControl.specialize({
+exports.Radio = class Radio extends CheckControl {
+    // <---- Properties ---->
 
-    // constructor: {
-    //     value: function InputRadio() {
-    //         this.super();
-    //         return this;
-    //     }
-    // },
+    drawsFocusOnPointerActivation = true;
 
-    drawsFocusOnPointerActivation: {
-        value: true
-    },
+    _radioButtonController = null;
 
-    hasTemplate: {
-        value: false
-    },
+    _keyComposer = null;
 
-    _keyComposer: {
-        value: null
-    },
-
-    _radioButtonController: {
-        value: null
-    },
-
-    enterDocument: {
-        value: function (firstTime) {
-            if (firstTime) {
-                this.element.setAttribute("role", "radio");
-            }
-        }
-    },
-
-    prepareForActivationEvents: {
-        value: function() {
-
-            this.super();
-
-            this._keyComposer = new KeyComposer();
-            this._keyComposer.component = this;
-            this._keyComposer.keys = "space";
-            this.addComposer(this._keyComposer);
-
-            this._keyComposer.addEventListener("keyPress", this, false);
-            this._keyComposer.addEventListener("keyRelease", this, false);
-        }
-    },
-
-    handleKeyPress: {
-        value: function () {
-            this.active = true;
-        }
-    },
-
-    handleKeyRelease: {
-        value: function () {
-            this.active = false;
-            this.check();
-        }
-    },
+    hasTemplate = false;
 
     /**
      * The radio button controller that ensures that only one radio button in
      * its `content` is `checked` at any time.
      * @type {RadioButtonController}
      */
-    radioButtonController: {
-        set: function (value) {
-            if (this._radioButtonController) {
-                this._radioButtonController.unregisterRadioButton(this);
-            }
+    set radioButtonController(value) {
+        if (this._radioButtonController) {
+            this._radioButtonController.unregisterRadioButton(this);
+        }
 
-            this._radioButtonController = value;
+        this._radioButtonController = value;
 
-            if (value) {
-                value.registerRadioButton(this);
-            }
-        },
-        get: function () {
-            return this._radioButtonController;
+        if (value) {
+            value.registerRadioButton(this);
         }
     }
 
-});
+    get radioButtonController() {
+        return this._radioButtonController;
+    }
+
+    // <---- Event Handlers ---->
+
+    handleKeyPress() {
+        this.active = true;
+    }
+
+    handleKeyRelease() {
+        this.active = false;
+        this.check();
+    }
+
+    // <---- Lifecycle Functions ---->
+
+    enterDocument(firstTime) {
+        if (firstTime) {
+            this.element.setAttribute("role", "radio");
+        }
+    }
+
+    /**
+     * Prepares the component for activation events.
+     * @override
+     * @protected
+     */
+    prepareForActivationEvents() {
+        super.prepareForActivationEvents();
+
+        this._keyComposer = new KeyComposer();
+        this._keyComposer.component = this;
+        this._keyComposer.keys = "space";
+        this.addComposer(this._keyComposer);
+
+        this._keyComposer.addEventListener("keyPress", this, false);
+        this._keyComposer.addEventListener("keyRelease", this, false);
+    }
+};

--- a/ui/radio.mod/radio.js
+++ b/ui/radio.mod/radio.js
@@ -10,15 +10,14 @@ const { CheckControl } = require("ui/check-control");
  * @extends module:mod/ui/check-input.CheckInput
  */
 exports.Radio = class Radio extends CheckControl {
-    // <---- Properties ---->
-
-    drawsFocusOnPointerActivation = true;
-
-    _radioButtonController = null;
-
-    _keyComposer = null;
-
-    hasTemplate = false;
+    static {
+        Montage.defineProperties(this.prototype, {
+            drawsFocusOnPointerActivation: { value: true },
+            _radioButtonController: { value: null },
+            _keyComposer: { value: null },
+            hasTemplate: { value: false },
+        });
+    }
 
     /**
      * The radio button controller that ensures that only one radio button in

--- a/ui/radio.mod/radio.js
+++ b/ui/radio.mod/radio.js
@@ -3,6 +3,7 @@
  */
 const { KeyComposer } = require("../../composer/key-composer");
 const { CheckControl } = require("ui/check-control");
+const { Montage } = require("core/core");
 
 /**
  * Wraps the a &lt;input type="radio"> element with binding support for the element's standard attributes.

--- a/ui/radio.mod/teach/ui/main.mod/main.css
+++ b/ui/radio.mod/teach/ui/main.mod/main.css
@@ -53,7 +53,7 @@ header {
 /* States --------------------- */
 
 .radio.custom.mod--active,
-.radio.custom.mod-RadioButton--checked {
+.radio.custom.montage--checked {
     background-color: currentColor;
 }
 
@@ -69,7 +69,7 @@ header {
     fill: transparent;
 }
 
-.radio.custom.mod-RadioButton--checked .radioCustomIcon {
+.radio.custom.montage--checked .radioCustomIcon {
     fill: inherit;
 }
 
@@ -91,7 +91,7 @@ header {
 }
 
 .radio.custom.mod--active,
-.radio.custom.mod-RadioButton--checked {
+.radio.custom.montage--checked {
     border-color: hsla(0,0%,70%,1);
     background-image: -webkit-linear-gradient(top, hsl(0,0%,90%), hsl(0,0%,86%) );
     background-image: -moz-linear-gradient(top, hsl(0,0%,90%), hsl(0,0%,86%) );

--- a/ui/radio.mod/teach/ui/main.mod/main.css
+++ b/ui/radio.mod/teach/ui/main.mod/main.css
@@ -53,7 +53,7 @@ header {
 /* States --------------------- */
 
 .radio.custom.mod--active,
-.radio.custom.montage--checked {
+.radio.custom.mod--checked {
     background-color: currentColor;
 }
 
@@ -69,7 +69,7 @@ header {
     fill: transparent;
 }
 
-.radio.custom.montage--checked .radioCustomIcon {
+.radio.custom.mod--checked .radioCustomIcon {
     fill: inherit;
 }
 
@@ -91,7 +91,7 @@ header {
 }
 
 .radio.custom.mod--active,
-.radio.custom.montage--checked {
+.radio.custom.mod--checked {
     border-color: hsla(0,0%,70%,1);
     background-image: -webkit-linear-gradient(top, hsl(0,0%,90%), hsl(0,0%,86%) );
     background-image: -moz-linear-gradient(top, hsl(0,0%,90%), hsl(0,0%,86%) );

--- a/ui/radio.mod/teach/ui/main.mod/main.js
+++ b/ui/radio.mod/teach/ui/main.mod/main.js
@@ -1,6 +1,3 @@
-var Component = require("mod/ui/component").Component;
+const { Component } = require("mod/ui/component");
 
-exports.Main = Component.specialize(/** @lends Main# */ {
-
-
-});
+exports.Main = class Main extends Component {};

--- a/ui/toggle.mod/teach/ui/main.mod/main.css
+++ b/ui/toggle.mod/teach/ui/main.mod/main.css
@@ -27,14 +27,14 @@ h4 {
     margin: 40px 0;
 }
 
-.mod-toggle.montage--checked.blue {
+.mod-toggle.mod--checked.blue {
     background-color: #488aff;
 }
 
-.mod-toggle.montage--checked.red {
+.mod-toggle.mod--checked.red {
     background-color: #f53d3d;
 }
 
-.mod-toggle.montage--checked.yellow {
+.mod-toggle.mod--checked.yellow {
     background-color: #ffc527;
 }

--- a/ui/toggle.mod/teach/ui/main.mod/main.js
+++ b/ui/toggle.mod/teach/ui/main.mod/main.js
@@ -1,3 +1,4 @@
-var Component = require("mod/ui/component").Component;
+const { Component } = require("mod/ui/component");
 
-exports.Main = Component.specialize();
+exports.Main = class Main extends Component {
+};

--- a/ui/toggle.mod/teach/ui/main.mod/main.js
+++ b/ui/toggle.mod/teach/ui/main.mod/main.js
@@ -1,4 +1,3 @@
 const { Component } = require("mod/ui/component");
 
-exports.Main = class Main extends Component {
-};
+exports.Main = class Main extends Component {};

--- a/ui/toggle.mod/toggle.css
+++ b/ui/toggle.mod/toggle.css
@@ -10,51 +10,51 @@
     border: 2px solid #e6e6e6;
     cursor: pointer;
     -webkit-user-select: none;
-       -moz-user-select: none;
-        -ms-user-select: none;
-            user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
     -webkit-tap-highlight-color: transparent;
-    -webkit-transition: background-color .3s cubic-bezier(.5,.15,.2,1);
-    transition: background-color .3s cubic-bezier(.5,.15,.2,1);
-}
+    -webkit-transition: background-color .3s cubic-bezier(.5, .15, .2, 1);
+    transition: background-color .3s cubic-bezier(.5, .15, .2, 1);
 
+    /* States --------------------- */
 
-/* Thumb --------------------- */
+    &.montage--checked {
+        background-color: #32db64;
+        border-color: transparent;
 
-.mod-toggle-thumb {
-    position: absolute;
-    box-sizing: border-box;
-    display: inline-block;
-    left: 0;
-    margin: -1px;
-    border-radius: 1em;
-    width: 1.75em;
-    height: 1.75em;
-    border: 1px solid #e6e6e6;
-    background-clip: content-box;
-    background-color: #fff;
-    box-shadow: 0 3px 12px rgba(0,0,0,.16), 0 3px 1px rgba(0,0,0,.1);
-    -webkit-transition: -webkit-transform .2s cubic-bezier(.5,.15,.2,1);
-    transition: -webkit-transform .2s cubic-bezier(.5,.15,.2,1);
-    transition: transform .2s cubic-bezier(.5,.15,.2,1);
-    transition: transform .2s cubic-bezier(.5,.15,.2,1), -webkit-transform .2s cubic-bezier(.5,.15,.2,1);
-    -webkit-transform: translate3d(0,0,0);
-            transform: translate3d(0,0,0);
-}
+        >.mod-toggle-thumb {
+            -webkit-transform: translate3d(70%, 0, 0);
+            transform: translate3d(70%, 0, 0);
+        }
+    }
 
+    &.mod--disabled {
+        /* FIXME: Temporary arbitrary values, waiting for Themes */
+        opacity: 0.5;
+        pointer-events: none;
+    }
 
-/* States --------------------- */
+    /* Thumb --------------------- */
 
-.mod-toggle.montage--checked {
-    background-color: #32db64;
-    border-color: transparent;
-}
-
-.mod-toggle[disabled] {
-    opacity: .5;
-}
-
-.mod-toggle.montage--checked .mod-toggle-thumb {
-    -webkit-transform: translate3d(70%,0,0);
-            transform: translate3d(70%,0,0);
+    >.mod-toggle-thumb {
+        position: absolute;
+        box-sizing: border-box;
+        display: inline-block;
+        left: 0;
+        margin: -1px;
+        border-radius: 1em;
+        width: 1.75em;
+        height: 1.75em;
+        border: 1px solid #e6e6e6;
+        background-clip: content-box;
+        background-color: #fff;
+        box-shadow: 0 3px 12px rgba(0, 0, 0, .16), 0 3px 1px rgba(0, 0, 0, .1);
+        -webkit-transition: -webkit-transform .2s cubic-bezier(.5, .15, .2, 1);
+        transition: -webkit-transform .2s cubic-bezier(.5, .15, .2, 1);
+        transition: transform .2s cubic-bezier(.5, .15, .2, 1);
+        transition: transform .2s cubic-bezier(.5, .15, .2, 1), -webkit-transform .2s cubic-bezier(.5, .15, .2, 1);
+        -webkit-transform: translate3d(0, 0, 0);
+        transform: translate3d(0, 0, 0);
+    }
 }

--- a/ui/toggle.mod/toggle.css
+++ b/ui/toggle.mod/toggle.css
@@ -19,7 +19,8 @@
 
     /* States --------------------- */
 
-    &.montage--checked {
+    &.montage--checked,
+    &.mod--checked {
         background-color: #32db64;
         border-color: transparent;
 

--- a/ui/toggle.mod/toggle.js
+++ b/ui/toggle.mod/toggle.js
@@ -1,7 +1,7 @@
-var CheckControl = require("../check-control").CheckControl;
+const { CheckControl} = require("../check-control");
 
 /**
  * @class Toggle
  * @extends CheckControl
  */
-var Toggle = exports.Toggle = CheckControl.specialize();
+exports.Toggle = class Toggle extends CheckControl {};


### PR DESCRIPTION
- [CheckControl] : avoid to create a useless binding when the property `checkedClassName` is not defined
- [CheckControl]: avoid to use deprecated initEvent method
- [Radio]: fixed the broken teach app (custom radio)
- Converted CheckControl, Radio, Checkbox and Toggle components to ES6
- fixed: `mod--disabled` & `mod--active` class names were not properly set on child components (Radio, Checkbox and Toggle) due to the fact they were not calling the super constructor