### PR TITLE
Add CSS property value getter method

### DIFF
--- a/ui/component.js
+++ b/ui/component.js
@@ -4338,6 +4338,43 @@ Component.addClassProperties(
         }
     },
 
+    /**
+     * Retrieves CSS property values with intelligent component-aware lookup and fallback strategies.
+     *
+     * This method provides a sophisticated CSS property retrieval system that automatically
+     * generates component-scoped custom property names and implements a cascading fallback
+     * strategy. It caches computed styles for performance optimization and supports both
+     * custom CSS properties and standard CSS properties.
+     *
+     * The lookup follows this priority order:
+     * 1. Prefixed custom property: `--{prefix}-{component-name}-{property-name}`
+     * 2. Unprefixed custom property: `--{component-name}-{property-name}`
+     * 3. Raw CSS property: `{property-name}`
+     *
+     * @method getCSSPropertyValue
+     * @memberof Component
+     * @param {string} propertyName - The CSS property name to retrieve. Must be a non-empty string.
+     * @param {boolean} [useCustomProperties=true] - Whether to enable custom property lookup.
+     *   When false, only retrieves the raw CSS property value directly.
+     * @param {string} [prefix="mod"] - The prefix to use for custom properties.
+     *   Set to empty string or null to disable prefixed property lookup.
+     * @returns {string|null} The trimmed CSS property value, or null if the property is not found
+     *   or has no value. Empty strings are converted to null.
+     * @throws {Error} Throws an error if propertyName is not a string.
+     *
+     * @example
+     * // Basic usage - looks for component-scoped custom properties
+     * // For component "MyButton" and property "background-color":
+     * // 1. --mod-my-button-background-color
+     * // 2. --my-button-background-color
+     * // 3. background-color
+     * const bgColor = this.getCSSPropertyValue('background-color');
+     *
+     * @example
+     * // Disable custom properties - raw CSS property only
+     * const display = this.getCSSPropertyValue('display', false);
+     * // Returns: display property value directly, no custom property lookup
+     */
     getCSSPropertyValue: {
         value: function getCSSPropertyValue(propertyName, useCustomProperties = true, prefix = "mod") {
             if (!String.isString(propertyName) || propertyName.length === 0) {

--- a/ui/component.js
+++ b/ui/component.js
@@ -4340,7 +4340,7 @@ Component.addClassProperties(
 
     getCSSPropertyValue: {
         value: function getCSSPropertyValue(propertyName, useCustomProperties = true, prefix = "mod") {
-            if (!String.isString(propertyName)) {
+            if (!String.isString(propertyName) || propertyName.length === 0) {
                 throw new Error('Property name must be a non-empty string');
             }
 
@@ -4359,7 +4359,7 @@ Component.addClassProperties(
             let propertyValue = null;
 
             // 1. Prefixed property
-            if (String.isString(prefix)) {
+            if (String.isString(prefix) && prefix.length > 0) {
                 const prefixedProperty = `--${prefix}-${unprefixedProperty}`;
                 propertyValue = this._elementStyles.getPropertyValue(prefixedProperty);
             }


### PR DESCRIPTION
Add `getCSSPropertyValue` method that provides smart CSS property value retrieval with component-aware naming, flexible fallback strategies.

### Intelligent Property Lookup

- **Component-aware naming**: Automatically uses component name in kebab-case
- **Flexible prefix support**: Configurable prefix (defaults to "mod")
- **Cascading fallback strategy**: Tries multiple property variations

## How It Works

The method follows this lookup priority:

```javascript
// For component "MyComponent" and property "background-color"
// 1. Try prefixed: --mod-my-component-background-color
// 2. Try unprefixed: --my-component-background-color  
// 3. Fallback to raw: background-color
```