### PR TITLE
Feature/range controller selection range

### DIFF
--- a/core/range-controller.js
+++ b/core/range-controller.js
@@ -410,14 +410,6 @@ var RangeController = exports.RangeController = Montage.specialize( /** @lends R
     allowsMultipleSelection: {value: false},
 
     /**
-     * The minimum number of items that must be selected.
-     *
-     * @default 0
-     * @property {number}
-     */
-    minSelectionLength: {value: 0},
-
-    /**
      * The maximum number of items that can be selected.
      *
      * @default Infinity

--- a/ui/repetition.mod/repetition.js
+++ b/ui/repetition.mod/repetition.js
@@ -2182,8 +2182,7 @@ var Repetition = exports.Repetition = Component.specialize(/** @lends Repetition
                     }
 
                 } else if (this.allowsMultipleSelection) {
-                    // If we are at min selection length, we need to ignore this deselection
-                        iteration.selected = false;
+                    iteration.selected = false;
                 }
             }
 


### PR DESCRIPTION
Adds notion of maximum selection amount for a repetition / range controller in the case that a user should be allowed to select exactly / up to a certain number of options from a list. Such as "Choose 3 core strengths that describe you from the provided list". Added logic to repetition.js and range-controller.js to handle this selection limit and ignore selections made when already at the provided maximum.