### PR TITLE
Check MJSON files for typos and errors

### DIFF
--- a/data/model/digital-asset.mjson
+++ b/data/model/digital-asset.mjson
@@ -93,7 +93,7 @@
     "secureLocation": {
         "prototype": "core/meta/property-descriptor",
         "values": {
-            "name": "signedLocation",
+            "name": "secureLocation",
             "valueType": "URL"
         }
     },

--- a/data/model/geo/circle.mjson
+++ b/data/model/geo/circle.mjson
@@ -1,7 +1,7 @@
 {
     "root": {
         "prototype": "core/meta/module-object-descriptor",
-        "properties": {
+        "values": {
             "name": "Circle",
             "propertyDescriptors": [
                 {"@": "coordinates"},
@@ -25,7 +25,7 @@
 
     "coordinates": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "coordinates",
             "cardinality": 1,
             "valueDescriptor": {"@": "PositionDescriptor"}
@@ -34,7 +34,7 @@
 
     "radius": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "radius",
             "valueType": "number"
         }

--- a/data/model/geo/geometry.mjson
+++ b/data/model/geo/geometry.mjson
@@ -1,7 +1,7 @@
 {
     "root": {
         "prototype": "core/meta/module-object-descriptor",
-        "properties": {
+        "values": {
             "name": "Geometry",
             "propertyDescriptors": [
                 {"@": "identifier"},
@@ -16,7 +16,7 @@
 
     "identifier": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "identifier",
             "valueType": "string"
         }
@@ -24,7 +24,7 @@
 
     "coordinates": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "coordinates",
             "valueType": "object"
         }

--- a/data/model/geo/line-string.mjson
+++ b/data/model/geo/line-string.mjson
@@ -1,7 +1,7 @@
 {
     "root": {
         "prototype": "core/meta/module-object-descriptor",
-        "properties": {
+        "values": {
             "name": "LineString",
             "parent": {"@": "geometry"},
             "propertyDescriptors": [
@@ -21,7 +21,7 @@
 
     "identifier": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "identifier",
             "valueType": "string"
         }
@@ -33,7 +33,7 @@
 
     "coordinates": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "coordinates",
             "cardinality": -1,
             "valueType": "array",

--- a/data/model/geo/multi-line-string.mjson
+++ b/data/model/geo/multi-line-string.mjson
@@ -1,7 +1,7 @@
 {
     "root": {
         "prototype": "core/meta/module-object-descriptor",
-        "properties": {
+        "values": {
             "name": "MultiLineString",
             "parent": {"@": "geometry"},
             "propertyDescriptors": [
@@ -21,7 +21,7 @@
 
     "identifier": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "identifier",
             "valueType": "string"
         }
@@ -33,7 +33,7 @@
 
     "coordinates": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "coordinates",
             "description": "The coordinates member of a multi-line string is an array of line string geometries.",
             "cardinality": -1,

--- a/data/model/geo/multi-point.mjson
+++ b/data/model/geo/multi-point.mjson
@@ -1,7 +1,7 @@
 {
     "root": {
         "prototype": "core/meta/module-object-descriptor",
-        "properties": {
+        "values": {
             "name": "MultiPoint",
             "parent": {"@": "geometry"},
             "propertyDescriptors": [
@@ -21,7 +21,7 @@
 
     "identifier": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "identifier",
             "valueType": "string"
         }
@@ -33,7 +33,7 @@
 
     "coordinates": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "coordinates",
             "cardinality": -1,
             "valueType": "array",

--- a/data/model/geo/multi-polygon.mjson
+++ b/data/model/geo/multi-polygon.mjson
@@ -1,7 +1,7 @@
 {
     "root": {
         "prototype": "core/meta/module-object-descriptor",
-        "properties": {
+        "values": {
             "name": "MultiPolygon",
             "parent": {"@": "geometry"},
             "propertyDescriptors": [
@@ -21,7 +21,7 @@
 
     "identifier": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "identifier",
             "valueType": "string"
         }
@@ -33,7 +33,7 @@
 
     "coordinates": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "coordinates",
             "cardinality": -1,
             "valueType": "array",

--- a/data/model/geo/point.mjson
+++ b/data/model/geo/point.mjson
@@ -1,7 +1,7 @@
 {
     "root": {
         "prototype": "core/meta/module-object-descriptor",
-        "properties": {
+        "values": {
             "name": "Point",
             "parent": {"@": "geometry"},
             "propertyDescriptors": [
@@ -21,7 +21,7 @@
 
     "identifier": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "identifier",
             "valueType": "string"
         }
@@ -33,7 +33,7 @@
 
     "coordinates": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "coordinates",
             "cardinality": 1,
             "valueType": "object",

--- a/data/model/geo/polygon.mjson
+++ b/data/model/geo/polygon.mjson
@@ -1,7 +1,7 @@
 {
     "root": {
         "prototype": "core/meta/module-object-descriptor",
-        "properties": {
+        "values": {
             "name": "Polygon",
             "parent": {"@": "geometry"},
             "propertyDescriptors": [
@@ -21,7 +21,7 @@
 
     "identifier": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "identifier",
             "valueType": "string"
         }
@@ -33,7 +33,7 @@
 
     "coordinates": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "coordinates",
             "cardinality": -1,
             "valueType": "array",

--- a/data/model/geo/position.mjson
+++ b/data/model/geo/position.mjson
@@ -56,7 +56,7 @@
 
     "projection": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "projection",
             "cardinality": 1,
             "valueType": "object",

--- a/data/model/geo/projection.mjson
+++ b/data/model/geo/projection.mjson
@@ -35,7 +35,7 @@
 
     "units": {
         "prototype": "core/meta/property-descriptor",
-        "properties": {
+        "values": {
             "name": "units",
             "cardinality": 1,
             "valueType": "object"

--- a/data/model/identity.mjson
+++ b/data/model/identity.mjson
@@ -34,7 +34,7 @@
     "provider": {
         "prototype": "../../core/meta/property-descriptor",
         "values": {
-            "name": "scope",
+            "name": "provider",
             "cardinality": -1,
             "valueType": "object",
             "valueDescriptor": {"@": "IdentityProviderDescriptor"},
@@ -46,7 +46,7 @@
         "object": "./party/organization.mjson"
     },
     "ownerOrganization": {
-        "prototype": "core/meta/property-descriptor",
+        "prototype": "../../core/meta/property-descriptor",
         "values": {
             "name": "ownerOrganization",
             "cardinality": 1,

--- a/data/model/ordering-rule.mjson
+++ b/data/model/ordering-rule.mjson
@@ -30,7 +30,7 @@
                     { "@": "orderDescriptor" }
                 ]
             },
-            "propertyvalidationRules": [],
+            "validationRules": [],
             "objectDescriptorModule": { "%": "./ordering-rule.mjson" },
             "exportName": "OrderingRule",
             "module": { "%": "./ordering-rule" },

--- a/data/model/physical-dimension.mjson
+++ b/data/model/physical-dimension.mjson
@@ -27,7 +27,7 @@
     "name": {
         "prototype": "core/meta/property-descriptor",
         "values": {
-            "name": "value",
+            "name": "name",
             "valueType": "string"
         }
     },

--- a/data/model/unit.mjson
+++ b/data/model/unit.mjson
@@ -27,7 +27,7 @@
     "name": {
         "prototype": "core/meta/property-descriptor",
         "values": {
-            "name": "value",
+            "name": "name",
             "valueType": "string"
         }
     },

--- a/data/model/variable.mjson
+++ b/data/model/variable.mjson
@@ -75,7 +75,7 @@
             "cardinality": 1,
             "valueType": "object",
             "valueDescriptor": {"@": "DataObjectDescriptor"},
-            "description": "The scope object, high level, to be secialized, on which the expression is to be evaluated to produce a value for this variable"
+            "description": "The scope object, high level, to be serialized, on which the expression is to be evaluated to produce a value for this variable"
         }
     }
 


### PR DESCRIPTION
Fixed critical property name mismatches and inconsistencies in mjson files:

data/model root level fixes:
- digital-asset.mjson: Fixed secureLocation property name (was signedLocation)
- physical-dimension.mjson: Fixed name property (was value)
- identity.mjson: Fixed provider property name (was scope) and standardized prototype paths
- unit.mjson: Fixed name property (was value)
- ordering-rule.mjson: Fixed propertyvalidationRules typo (now validationRules)
- variable.mjson: Fixed description typo (secialized → serialized)

data/model/geo fixes:
- Standardized all geo files to use "values" instead of "properties"
- Affected files: line-string, multi-line-string, multi-point, polygon, point, circle, geometry, multi-polygon, projection, position

These fixes ensure property descriptors match their references and maintain consistency across the codebase.