### PR TITLE
Check messaging channel files for typos

### DIFF
--- a/data/model/messaging-channel/party-messaging-channel.mjson
+++ b/data/model/messaging-channel/party-messaging-channel.mjson
@@ -61,7 +61,7 @@
             "name": "personParty",
             "valueType": "object",
             "cardinality": 1,
-            "valueDescriptor": {"@": "OrganizationDescriptor"}
+            "valueDescriptor": {"@": "PersonDescriptor"}
         }
     },
     "PersonDescriptor": {

--- a/data/model/messaging-channel/phone-number.mjson
+++ b/data/model/messaging-channel/phone-number.mjson
@@ -56,7 +56,7 @@
             "name": "country",
             "valueType": "object",
             "cardinality": 1,
-            "valueDescriptor": {"@": "PartySMSNumberDescriptor"}
+            "valueDescriptor": {"@": "CountryDescriptor"}
         }
     },
     "nationalNumber": {
@@ -121,7 +121,7 @@
     "supportsRichCommunication": {
         "prototype": "core/meta/property-descriptor",
         "values": {
-            "name": "supportsiMessage",
+            "name": "supportsRichCommunication",
             "valueType": "boolean",
             "defaultValue": false,
             "description": "Indicates that the telephone number supports Rich Communication Services (RCS)"


### PR DESCRIPTION
- Fix country property to reference CountryDescriptor instead of PartySMSNumberDescriptor in phone-number.mjson
- Fix supportsRichCommunication property name field in phone-number.mjson
- Fix personParty property to reference PersonDescriptor instead of OrganizationDescriptor in party-messaging-channel.mjson