### PR TITLE
Bugfix/data trigger setter getter

### DIFF
--- a/core/collections/listen/array-changes.js
+++ b/core/collections/listen/array-changes.js
@@ -173,6 +173,13 @@ var observableArrayProperties = {
                 /*
                     There could be the same values at the same slot in plus
                     as in this. In which case they shouldn't be considered as minus
+
+                    #WARNING EXCEPTION WHEN this, plus are arrays of boolean, used by makeReplacingMapBlockObserver() and makeReplacingFilterBlockObserver()
+                    I, this case this implementation that replaces the OG:
+                        minus = array_slice.call(this, start, start + length);
+                    create a bug in filter-map-spec.js.
+
+                    So added a test to return to the OG behavior if values are boolean
                 */
                 let i, countI, newPlus = plus.slice(), newStart = start, myLength = this.length, iterationLength = (length > myLength ? myLength : length), newLength = iterationLength;
                 for(i = 0, countI = iterationLength; (i<countI); i++ ) {
@@ -180,7 +187,7 @@ var observableArrayProperties = {
                         (plusLength > 0) is to make the difference between this[i+start] actually containing the value undefined
                         vs plus being empty in which case plus[i] also returns undefined...
                     */
-                    if(plusLength > 0 && this[i+start] === plus[i] && !minus) {
+                    if(plusLength > 0 && ((this[i+start] === plus[i]) && (typeof plus[i] !== "boolean")) && !minus) {
                         newPlus.shift();
                         newStart++;
                         newLength--;

--- a/core/collections/shim-array.js
+++ b/core/collections/shim-array.js
@@ -545,6 +545,27 @@ define("includesAll", function (values) {
     return true;
 });
 
+/**
+ * Returns true if an array has a length of zero or it only contains undefined values
+ *
+ * @property
+ * @return {Boolean} 
+ */
+Object.defineProperty(Array.prototype, "isEmpty", {
+    get: function () {
+        if(this.length === 0 )return true;
+
+        for(let i=0, iCount = this.length; (i<iCount); i++) {
+            if(this[i] !== undefined) {
+                return false;
+            }
+        }
+        return true;
+    },
+    configurable: true,
+    enumerable: false
+});
+
 define("isContentEqual", function (otherArray) {
 
     if(this.length !== otherArray?.length){

--- a/core/environment.js
+++ b/core/environment.js
@@ -54,7 +54,9 @@ var Environment = exports.Environment = Montage.specialize({
     },
 
     /**
-     * The name of the stage the code is running.
+     * The name of the stage the code is running. This is not standardized yet. 
+     * What I used before was verb-based: "mod" —for local development, "test" —for testing, and "live" for the "real", "production", environment.
+     * "live" for going live, where things happen for everyone, a reminder that Mods are live by design. 
      *
      * this.application.url.searchParams.get("stage");
      *

--- a/core/event/change-event.js
+++ b/core/event/change-event.js
@@ -52,13 +52,50 @@ var ChangeEvent = exports.ChangeEvent = Montage.specialize({
     },
 
     /**
+     * The property whose value may have changed. Property feels like a better name than "key"
+     *
+     * @type {String}
+     * @default null
+     */
+    property: {
+        value: undefined
+    },
+    /**
      * The key/property whose value may have changed
      *
      * @type {String}
      * @default null
      */
     key: {
+        get: function () {
+            return this.property;
+        },
+        set: function (value) {
+            this.property = value;
+        }
+    },
+
+    /**
+     * The property for target's property
+     *
+     * @type {PropertyDescriptor}
+     * @default null
+     */
+    _propertyDescriptor: {
         value: undefined
+    },
+    propertyDescriptor: {
+        get: function () {
+            if(!this._propertyDescriptor) {
+                this._propertyDescriptor = this.target.objectDescriptor.propertyDescriptorNamed(this.property);
+            }
+            return this._propertyDescriptor;
+        },
+        set: function (value) {
+            if(value !== this._propertyDescriptor) {
+                this._propertyDescriptor = value;
+            }
+        }
     },
 
     /**
@@ -67,8 +104,16 @@ var ChangeEvent = exports.ChangeEvent = Montage.specialize({
      * @type {Object}
      * @default null
      */
-    previousKeyValue: {
+    previousPropertyValue: {
         value: undefined
+    },
+    previousKeyValue: {
+        get: function () {
+            return this.previousPropertyValue;
+        },
+        set: function (value) {
+            this.previousPropertyValue = value;
+        }
     },
 
     /**
@@ -77,9 +122,18 @@ var ChangeEvent = exports.ChangeEvent = Montage.specialize({
      * @type {Object}
      * @default null
      */
-    keyValue: {
+    propertyValue: {
         value: undefined
     },
+    keyValue: {
+        get: function () {
+            return this.propertyValue;
+        },
+        set: function (value) {
+            this.propertyValue = value;
+        }
+    },
+
 
     /**
      * Alternative: group all range changes under 1 typed RangeChange object that

--- a/core/event/event-manager.js
+++ b/core/event/event-manager.js
@@ -1443,8 +1443,8 @@ var EventManager = exports.EventManager = Montage.specialize(/** @lends EventMan
 
     _isDOMTargetChangeListener: {
         enumerable: false,
-        value: function _isDOMTargetChangeListener(target, eventType) {
-            return (eventType === "change" && this.isBrowser && 
+        value: function _isDOMTargetChangeListener(target, eventType, optionsOrUseCapture) {
+            return (eventType === "change" && this.isBrowser && optionsOrUseCapture?.hasOwnProperty("size") && 
                (target instanceof Element || (typeof SVGElement !== "undefined" && target instanceof SVGElement)));
         }
     },
@@ -1477,7 +1477,7 @@ var EventManager = exports.EventManager = Montage.specialize(/** @lends EventMan
                 // }
             // }
 
-            if(this._isDOMTargetChangeListener(target, eventType)) {
+            if(this._isDOMTargetChangeListener(target, eventType, optionsOrUseCapture)) {
                 this._resizeObserver.observe(target, {box: optionsOrUseCapture?.size?.box});
             }
 
@@ -1558,7 +1558,7 @@ var EventManager = exports.EventManager = Montage.specialize(/** @lends EventMan
                 ? targetEntryForEventType.delete(Event_CAPTURING_PHASE)
                 : targetEntryForEventType.delete(Event_BUBBLING_PHASE)
             }
-            if(this._isDOMTargetChangeListener(target, eventType)) {
+            if(this._isDOMTargetChangeListener(target, eventType, optionsOrUseCapture)) {
                 this._resizeObserver.unobserve(target);
             }
 

--- a/core/extras/element.js
+++ b/core/extras/element.js
@@ -1,5 +1,7 @@
 
 if (typeof Element !== "undefined" && !Element.isElement) {
+    exports.Element = Element;
+    
     Object.defineProperty(Element, "isElement", {
         value: function (obj) {
             return !!(obj && 1 === obj.nodeType);

--- a/core/extras/object.js
+++ b/core/extras/object.js
@@ -121,3 +121,22 @@ if (Object.prototype.hasOwnProperty('isEmpty') === false) {
         enumerable: false
     });
 }
+
+/**
+ * Returns all keys of an object, owned and inherited ones
+ * @param {Object} object The object to return all keys for.
+ * @returns {Array<String>} An array containing all keys
+ */
+if (Object.prototype.hasOwnProperty('allKeys') === false) {
+    Object.defineProperty(Object, "allKeys", {
+        value: function (object) {
+            const allKeys = [];
+            for (var key in object) allKeys.push(key);
+            return allKeys;
+        },
+        configurable: true,
+        writable: true,
+        enumerable: false
+
+    });
+}

--- a/core/frb/scope.js
+++ b/core/frb/scope.js
@@ -11,4 +11,34 @@ Scope.prototype.nest = function (value) {
     child.parent = this;
     return child;
 };
+/**
+ * Discovers, cache and return the root scope of this scope.
+ * WARNING: This is cached. So it could get staled if the Scope hierararchy is manually patched
+ * The only public API today is extending downwaed with .nest(value)
+ *
+ * @property
+ * @return {Scope} 
+ */
+
+Object.defineProperties(Scope.prototype, {
+    _root: {
+        value: undefined,
+        enumerable: false,
+        writable: true
+    },
+    root: {
+        get: function() {
+            if(!this._root) {
+                let child = this,
+                    parent;
+                while(child.parent) {
+                    child.parent.child = child;
+                    child = child.parent;
+                }
+                this._root = child;
+            }
+            return this._root;
+        }
+    }
+});
 

--- a/core/meta/object-descriptor.js
+++ b/core/meta/object-descriptor.js
@@ -9,6 +9,8 @@ var Montage = require("../core").Montage,
     Promise = require("../promise").Promise,
     PropertyDescriptor = require("./property-descriptor").PropertyDescriptor,
     Set = require("../collections/set"),
+    parse = require("../frb/parse"),
+    SyntaxInOrderIterator = require("core/frb/syntax-iterator").SyntaxInOrderIterator,
     deprecate = require("../deprecate");
 
 var Defaults = {
@@ -679,6 +681,65 @@ ObjectDescriptor.addClassProperties(
 
                 return this._composedPath;
             },
+        },
+
+        _descriptorTraversingExpression: {
+            value: function(anExpression, _returnTraversedDescriptors = false) {
+                let syntax = parse(anExpression),
+                syntaxIterator = new SyntaxInOrderIterator(syntax),
+                currentIteration,
+                currentSyntax,
+                traversedDescriptors = _returnTraversedDescriptors ? [] : null,
+                descriptor = this;
+
+                while (
+                    (currentIteration = syntaxIterator.next(undefined, currentSyntax)) &&
+                    currentIteration.done !== true
+                ) {
+
+                    //A filter{} is just a reduction in content, it doesn't change the type to continue
+                    //A map{} however will change the type to consider going forward.
+                    //We're going to need a spec to get this right
+
+                    currentSyntax = currentIteration.value;
+                    if(currentSyntax.type === "property") {
+                        /*
+                            currentSyntax: {"type":"property","args":[{"type":"value"},{"type":"literal","value":"userIdentities"}]}
+                        */
+                        let propertyName = currentSyntax.args[1].value,
+                            propertyDescriptor = descriptor.propertyDescriptorNamed(propertyName);
+
+                        //WARNING: propertyDescriptor.valueDescriptor is a promise, which means descriptorTraversingExpression should return a promise
+                        //And every method calling this would have to deal with it, hint: composedPath
+                        if(propertyDescriptor._valueDescriptorReference) {
+                            descriptor = propertyDescriptor._valueDescriptorReference;
+
+                            //We only have an array in traversedDescriptors if _returnTraversedDescriptors === true
+                            traversedDescriptors?.push(descriptor)
+                        }
+
+                    } else if(currentSyntax.type === "map") {
+
+                    } else {
+                        //I think we want to skip to the next property
+                    }
+
+                }
+
+                return traversedDescriptors ? traversedDescriptors : descriptor;
+            }
+        },
+
+        descriptorTerminatingExpression: {
+            value: function(anExpression) {
+                return this._descriptorTraversingExpression(anExpression, false);
+            }
+        },
+
+        descriptorsTraversingExpression: {
+            value: function(anExpression) {
+                return this._descriptorTraversingExpression(anExpression, true);
+            }
         },
 
         /**

--- a/core/uuid.js
+++ b/core/uuid.js
@@ -286,6 +286,9 @@ var Uuid = exports.Uuid = Object.create(Object.prototype, /** @lends Uuid# */ {
     isUUID: {
         enumerable: false,
         value: exports.isUUID
+    },
+    noValue: {
+        value: '00000000-0000-0000-0000-000000000000'
     }
 });
 

--- a/data/converter/raw-foreign-value-to-object-converter.js
+++ b/data/converter/raw-foreign-value-to-object-converter.js
@@ -3,6 +3,7 @@ var RawValueToObjectConverter = require("./raw-value-to-object-converter").RawVa
     DataQuery = require("../model/data-query").DataQuery,
     Map = require("../../core/collections/map").Map,
     syntaxProperties = require("../../core/frb/syntax-properties"),
+    Uuid = require("core/uuid").Uuid,
     Promise = require("../../core/promise").Promise;
 /**
  * @class RawForeignValueToObjectConverter
@@ -690,6 +691,10 @@ exports.RawForeignValueToObjectConverter = RawValueToObjectConverter.specialize(
         }
     },
 
+    uuidNoValue: {
+        value: Uuid.noValue
+    },
+
    _convert: {
         value: function (scope, service) {
             var v = scope.value;
@@ -765,6 +770,12 @@ exports.RawForeignValueToObjectConverter = RawValueToObjectConverter.specialize(
                         }
                     }
 
+                } else if(v === this.uuidNoValue) {
+                    /*
+                        the uuid noValue - '00000000-0000-0000-0000-000000000000'
+                        means there's nothing to be found, we can resolve this right now!
+                    */
+                    return Promise.resolveNull;
                 } else {
                     criteria = this.convertCriteriaForValue(v);
 
@@ -847,7 +858,7 @@ exports.RawForeignValueToObjectConverter = RawValueToObjectConverter.specialize(
 
                 //     });
                 // } else {
-                    return Promise.resolve(null);
+                    return Promise.resolveNull;
                 //}
 
             }

--- a/data/model/data-query.js
+++ b/data/model/data-query.js
@@ -325,11 +325,22 @@ exports.DataQuery = ObjectSpecification.specialize(/** @lends DataQuery.prototyp
      * It is used for example to carry an object's originDataSnapshot if present, 
      * or to pass an object's snapshot to provide context needed to a stateless, serverless
      * Mod worker processing DataOperations 
-     * @type {Object}
+     * @property {Object}
      */
 
     hints: {
         value: undefined
+    },
+
+    /**
+     * Returns true if existing instances are overwritten with fetched values when they’ve been updated or changed. 
+     * Returns false if existing instances aren’t touched when their data is refetched (the feched data is simply discarded). 
+     * The default is false. Note that this setting does not affect relationships.
+     * 
+     * @property {Boolean}
+     */
+    refreshesRefetchedInstances: {
+        value: false
     },
 
 

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -4647,7 +4647,7 @@ DataService.addClassProperties(
                     */
 
                     //If both array contain the same values, there's nothing to do from a relationship/graph management stand point 
-                    if(addedValues.isContentEqual(removedValues)) {
+                    if (addedValues.isContentEqual(removedValues)) {
                         return;
                     }
 
@@ -4656,6 +4656,7 @@ DataService.addClassProperties(
                     //that itself has two keys: addedValues and removedValues
                     //which value will be a set;
                     var manyChanges = changesForDataObject.get(key),
+                        isManyChangesArray = manyChanges && Array.isArray(manyChanges),
                         i,
                         countI;
 
@@ -4672,27 +4673,13 @@ DataService.addClassProperties(
                     // The indices at which to make the 2nd and 3rd changes are lost. 
 
                     if (!manyChanges) {
-                        manyChanges = {index: changeEvent.index};
+                        manyChanges = new CollectionChanges();
                         changesForDataObject.set(key, manyChanges);
-                    }
+                    } 
+                    
 
-                    //Not sure if we should consider evaluating added values regarded
-                    //removed ones, one could be added and later removed.
-                    //We later need to convert these into dataIdentifers, we could avoid a loop later
-                    //doing so right here.
-
-                    /*
-                        Benoit 1/8/26 - Got a use-case of a swap: same values in addedValues and removedValues.
-                        But with processing removedValues being the last, it would empty the array...
-
-                        So removedValues needs to be handles first, and then addedValues second
-                    */
-                    if (removedValues) {
-                        /*
-                        In this case, the array already contains the added value and we'll save it all anyway. So we just propagate.
-                        If the change is triggered by resolving properties by the framewok itself, then isDataObjectBeingMapped is true, and we don't want to register any of it as a change
-                    */
-                        if (Array.isArray(manyChanges) && (isCreatedObject || isDataObjectBeingMapped)) {
+                    if (isManyChangesArray && (isCreatedObject || isDataObjectBeingMapped)) {
+                        if (removedValues) {
                             self._removeDataObjectPropertyDescriptorValuesForInversePropertyDescriptor(
                                 dataObject,
                                 propertyDescriptor,
@@ -4700,57 +4687,8 @@ DataService.addClassProperties(
                                 inversePropertyDescriptor,
                                 isDataObjectBeingMapped
                             );
-                        } else {
-                            var registeredRemovedValues = manyChanges.removedValuesSet;
-                            if (!registeredRemovedValues) {
-                                if (!isDataObjectBeingMapped) {
-                                    manyChanges.removedValues = removedValues;
-                                    manyChanges.removedValuesSet = registeredRemovedValues = new Set(removedValues);
-                                }
-                                self._removeDataObjectPropertyDescriptorValuesForInversePropertyDescriptor(
-                                    dataObject,
-                                    propertyDescriptor,
-                                    removedValues,
-                                    inversePropertyDescriptor,
-                                    isDataObjectBeingMapped
-                                );
-                            } else {
-                                for (i = 0, countI = removedValues.length; i < countI; i++) {
-                                    if (!isDataObjectBeingMapped) {
-                                        registeredRemovedValues.add(removedValues[i]);
-                                        manyChanges.removedValues.push(removedValues[i]);
-                                    }
-                                    self._removeDataObjectPropertyDescriptorValueForInversePropertyDescriptor(
-                                        dataObject,
-                                        propertyDescriptor,
-                                        removedValues[i],
-                                        inversePropertyDescriptor,
-                                        isDataObjectBeingMapped
-                                    );
-                                }
-                            }
                         }
-                        /*
-                        Work on local graph integrity. When objects are disassociated, it could mean some deletions may happen bases on delete rules.
-                        App side goal is to maintain the App graph, server's side is to maintain database integrity. Both needs to act on delete rules:
-                        - get object's descriptor
-                        - get PropertyDescriptor from key
-                        - get PropertyDescriptor's .deleteRule
-                            deleteRule can be:
-                                - DeleteRule.NULLIFY
-                                - DeleteRule.CASCADE
-                                - DeleteRule.DENY
-                                - DeleteRule.IGNORE
-                    */
-
-                        //,,,,,TODO
-                    }
-
-                    if (addedValues) {
-                        /*
-                        In this case, the array already contains the added value and we'll save it all anyway. So we just propagate.
-                    */
-                        if (Array.isArray(manyChanges) && (isCreatedObject || isDataObjectBeingMapped)) {
+                        if (addedValues) {
                             self._addDataObjectPropertyDescriptorValuesForInversePropertyDescriptor(
                                 dataObject,
                                 propertyDescriptor,
@@ -4758,57 +4696,72 @@ DataService.addClassProperties(
                                 inversePropertyDescriptor,
                                 isDataObjectBeingMapped
                             );
-                        } else {
-                            var registeredAddedValues = manyChanges.addedValuesSet;
-                            if (!registeredAddedValues) {
-                                /*
-                                FIXME: we ended up here with manyChanges being an array, containing the same value as addedValues. And we end up setting addedValues property on that array. So let's correct it. We might not want to track toMany as set at all, and just stick to added /remove. This might happens on remove as well, we need to check further.
-                            */
-                                if (Array.isArray(manyChanges) && manyChanges.equals(addedValues)) {
-                                    manyChanges = {};
-                                    manyChanges.index = changeEvent.index;
-                                    changesForDataObject.set(key, manyChanges);
-                                }
+                        }
+                    } else {
 
+                        if (addedValues && isManyChangesArray && manyChanges.equals(addedValues)) {
+                            manyChanges = new CollectionChanges();
+                            changesForDataObject.set(key, manyChanges);
+                        }
+                        manyChanges.trackChangeEvent(changeEvent);
+
+                        if (removedValues) {
+                            registeredRemovedValues = manyChanges.removedValues;
+
+                            if (isDataObjectBeingMapped) {
+                                let targetName = changeEvent.target instanceof ObjectDescriptor ? changeEvent.target.name : changeEvent.target.dataIdentifier?.typeName;
+                                
+                                console.warn(`[DataService] RemovedValue during mapping? ${targetName}.${changeEvent.key}`);
+                            }
+                        
+
+                            for (i = 0, countI = removedValues.length; i < countI; i++) {
                                 if (!isDataObjectBeingMapped) {
-                                    manyChanges.addedValues = addedValues;
-                                    manyChanges.addedValuesSet = registeredAddedValues = new Set(addedValues);
+                                    registeredRemovedValues.add(removedValues[i]);
                                 }
-                                self._addDataObjectPropertyDescriptorValuesForInversePropertyDescriptor(
+                                self._removeDataObjectPropertyDescriptorValueForInversePropertyDescriptor(
                                     dataObject,
                                     propertyDescriptor,
-                                    addedValues,
+                                    removedValues[i],
                                     inversePropertyDescriptor,
                                     isDataObjectBeingMapped
                                 );
-                            } else {
-                                let shouldAdd = true;
-                                for (i = 0, countI = addedValues.length; i < countI; i++) {
-                                    if (!isDataObjectBeingMapped) {
-                                        if (!registeredAddedValues.has(addedValues[i])) {
-                                            registeredAddedValues.add(addedValues[i]);
-                                            manyChanges.addedValues.push(addedValues[i]);
-                                            shouldAdd = true;
-                                        } else if (!addedValues[i]) {
-                                            shouldAdd = true;
-                                        } else {
-                                            shouldAdd = false;
-                                        }
-                                    }
-                                    if (shouldAdd) {
-                                        self._addDataObjectPropertyDescriptorValueForInversePropertyDescriptor(
-                                            dataObject,
-                                            propertyDescriptor,
-                                            addedValues[i],
-                                            inversePropertyDescriptor,
-                                            isDataObjectBeingMapped
-                                        );
-                                    }
+                            }
+                        }
 
+                        if (addedValues) {
+                            registeredAddedValues = manyChanges.addedValues;
+
+                            if (isDataObjectBeingMapped) {
+                                let targetName = changeEvent.target instanceof ObjectDescriptor ? changeEvent.target.name : changeEvent.target.dataIdentifier?.typeName;
+                                console.warn(`[DataService] Add value during mapping? ${targetName}.${changeEvent.key}`);
+                            }
+                            let shouldAdd = true;
+                            for (i = 0, countI = addedValues.length; i < countI; i++) {
+                                if (!isDataObjectBeingMapped) {
+                                    if (!registeredAddedValues.has(addedValues[i])) {
+                                        registeredAddedValues.add(addedValues[i]);
+                                        shouldAdd = true;
+                                    } else if (!addedValues[i]) {
+                                        shouldAdd = true;
+                                    } else {
+                                        shouldAdd = false;
+                                    }
+                                }
+                                if (shouldAdd) {
+                                    self._addDataObjectPropertyDescriptorValueForInversePropertyDescriptor(
+                                        dataObject,
+                                        propertyDescriptor,
+                                        addedValues[i],
+                                        inversePropertyDescriptor,
+                                        isDataObjectBeingMapped
+                                    );
                                 }
                             }
                         }
                     }
+
+                    return;
 
                 }
             },
@@ -9088,3 +9041,114 @@ DataService.defineBinding("mainService", { "<-": "application.mainService", sour
 
 //WARNING Shouldn't be a problem, but avoiding a potential require-cycle for now:
 DataStream.DataService = exports.DataService;
+
+
+/******
+ * Tracks the changes to a collection between saves
+ */
+
+function CollectionChanges() {}
+Object.defineProperties(CollectionChanges.prototype, {
+
+
+    /***
+     *  The ids of the Change Events recorded in this object
+     *   @property {Set}
+    ***/
+    _trackedEventIds: {
+        get: function () {
+            return this.__trackedEventIds || (this.__trackedEventIds = new Set());
+        }
+    },
+
+    /***
+     *  The ordered changes for the tracked collection. The structure of each item in this array will change
+     *  based on the type of collection being tracked. 
+     * 
+     * Array: 
+     *  {
+     *    index: integer
+     *    addedValues: Array
+     *    removedValues: Array
+     *  }
+     * 
+     * Set: (no current use case)
+     *  {
+     *    addedValues: Set
+     *    removedValues: Set
+     *  }
+     * 
+     *  Map: (no current use case)
+     *  {
+     *    addedValues: Array -- [{key: key, value: value}]
+     *    removedValues: Array
+     *  }
+     *   @property {Array}
+    ***/
+    changes: {
+        get: function () {
+            return this._changes || (this._changes = []);
+        }
+    },
+
+    hasChanges: {
+        get: function () {
+
+            //FIXME: Use/test this._changes?.length > 0
+            return this._changes && this._changes.length > 0;
+        }
+    },
+
+    /***
+     *  All values added to the collection
+     *   @property {Set}
+    ***/
+    addedValues: {
+        get: function () {
+            return this._addedValues || (this._addedValues = new Set());
+        }
+    },
+
+    /***
+     *  Returns whether any values have been added or removed
+     *   @property {Set}
+    ***/
+    hasAddedOrRemovedValues: {
+        get: function () {
+            //FIXME: Use/test this._changes?.length > 0
+            return (this._addedValues && this._addedValues.size > 0) || (this._removedValues && this._removedValues.size > 0);
+        }
+    },
+
+    /***
+     *  All values removed from the collection
+     *   @property {Set}
+    ***/
+    removedValues: {
+        get: function () {
+            return this._removedValues || (this._removedValues = new Set());
+        }
+    },
+
+    /***
+     *  Add an entry to the changes array for a given change event
+     * 
+     * This could be updated to:
+     * - Add values to addedValues
+     * - Add values to removedValues
+     * - Check the type of the property to add an object with the correct structure to changes
+    ***/
+    trackChangeEvent: {
+        value: function (changeEvent) {
+            if (!this._trackedEventIds.has(changeEvent.id)) {
+                this._trackedEventIds.add(changeEvent.id);
+                this.changes.push({
+                    index: changeEvent.index,
+                    addedValues: changeEvent.addedValues,
+                    removedValues: changeEvent.removedValues
+                })
+            }
+        }
+    }
+
+})

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -2406,7 +2406,7 @@ DataService.addClassProperties(
          * in object.
          */
         fetchObjectProperty: {
-            value: function (object, propertyName, isObjectCreated, readExpressions) {
+            value: function (object, propertyName, isObjectCreated, isUpdate) {
                 var childServices = this.childServicesForType(object.objectDescriptor),
                     isHandler =
                         /*(this.parentService && this.parentService._getChildServiceForObject(object) === this)*/ this.handlesType(
@@ -2447,17 +2447,17 @@ DataService.addClassProperties(
                       )
                     : childServices?.length > 0
                     ? childServices.length === 1
-                        ? childServices[0].fetchObjectProperty(object, propertyName, isObjectCreated)
-                        : this.childServicesFetchObjectProperty(object, propertyName, isObjectCreated)
+                        ? childServices[0].fetchObjectProperty(object, propertyName, isObjectCreated, isUpdate)
+                        : this.childServicesFetchObjectProperty(object, propertyName, isObjectCreated, isUpdate)
                     : this.nullPromise;
             },
         },
 
         childServicesFetchObjectProperty: {
-            value: function (object, propertyName, isObjectCreated) {
+            value: function (object, propertyName, isObjectCreated, isUpdate) {
                 //Workaround for now:
                 if (object.dataIdentifier.dataService) {
-                    return object.dataIdentifier.dataService.fetchObjectProperty(object, propertyName, isObjectCreated);
+                    return object.dataIdentifier.dataService.fetchObjectProperty(object, propertyName, isObjectCreated, isUpdate);
                 }
 
                 throw "Data Services with multiple child services per ObjectDescriptor have to implement this method";

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -4773,11 +4773,17 @@ DataService.addClassProperties(
                                 let shouldAdd = true;
                                 for (i = 0, countI = addedValues.length; i < countI; i++) {
                                     if (!isDataObjectBeingMapped) {
-                                        shouldAdd = !addedValues[i] || !registeredAddedValues.has(addedValues[i]);
-                                        registeredAddedValues.add(addedValues[i]);
+                                        if (!registeredAddedValues.has(addedValues[i])) {
+                                            registeredAddedValues.add(addedValues[i]);
+                                            manyChanges.addedValues.push(addedValues[i]);
+                                            shouldAdd = true;
+                                        } else if (!addedValues[i]) {
+                                            shouldAdd = true;
+                                        } else {
+                                            shouldAdd = false;
+                                        }
                                     }
                                     if (shouldAdd) {
-                                        manyChanges.addedValues.push(addedValues[i])
                                         self._addDataObjectPropertyDescriptorValueForInversePropertyDescriptor(
                                             dataObject,
                                             propertyDescriptor,

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -1337,8 +1337,15 @@ DataService.addClassProperties(
         },
 
         /**
-         * Get all child services that handle dataOperationtype of the specified type argument,
-         * or `null` if no such child service exists.
+         * Get all child services that handle a dataOperation, which can mean:
+         *  - handling the type of operation — dataOperation.type
+         *  - handling the object descriptor involved - dataOperation.target
+         *  - but also handling the readExpressions involved — dataOperation.data.readExpresssions
+         *    
+         * Just because a RawDataService can read objects of a certain type, doesn't necessarily means 
+         * it can resolves a property/relationship on the source object descriptor (dataOperation.target) to that type
+         *
+         * TODO: ADD CACHING
          *
          * @method
          * @argument {DataOperationType} dataOperationtype

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -4659,9 +4659,20 @@ DataService.addClassProperties(
                         i,
                         countI;
 
+                    //TODO The logic for tracking array changes uses the index at which the change occured a la handleRangeChange(plus, minus, index). 
+                    // The problem is that it assumes there was a single action taken at a single index within a save cycle. 
+                    //Example: foo.bar = [A, B, C, D, E, F, G];
+                    //
+                    // foo.bar.splice(2, 2); Removes 2 items at index 2 so change event has index 2
+                    // foo.bar.push(H); Adds item to end of array so change event has index 5 
+                    // foo.bar.unshift(Z); Adds item to beginning of array so change event has index 0
+                    // saveChanges();
+                    // 
+                    // The index captured in dataObjectChanges is the one from the first change event, so 2. 
+                    // The indices at which to make the 2nd and 3rd changes are lost. 
+
                     if (!manyChanges) {
-                        manyChanges = {};
-                        manyChanges.index = changeEvent.index;
+                        manyChanges = {index: changeEvent.index};
                         changesForDataObject.set(key, manyChanges);
                     }
 
@@ -4707,6 +4718,7 @@ DataService.addClassProperties(
                                 for (i = 0, countI = removedValues.length; i < countI; i++) {
                                     if (!isDataObjectBeingMapped) {
                                         registeredRemovedValues.add(removedValues[i]);
+                                        manyChanges.removedValues.push(removedValues[i]);
                                     }
                                     self._removeDataObjectPropertyDescriptorValueForInversePropertyDescriptor(
                                         dataObject,

--- a/data/service/data-service.js
+++ b/data/service/data-service.js
@@ -2698,8 +2698,8 @@ DataService.addClassProperties(
                     promise = !trigger
                         ? this.nullPromise
                         : isUpdate
-                        ? trigger.updateObjectProperty(object)
-                        : trigger.getObjectProperty(object);
+                            ? trigger.updateObjectProperty(object)
+                            : trigger.getObjectProperty(object);
                     if (promise !== this.nullPromise) {
                         if (!promises) {
                             promises = { array: [promise] };

--- a/data/service/data-trigger.js
+++ b/data/service/data-trigger.js
@@ -410,7 +410,18 @@ exports.DataTrigger.prototype = Object.create(
                     } else {
                         initValue = new valueClass();
                     }
-                    this._setValue(object, /*value*/initValue, /*_dispatchChange*/false, /*_initialValue*/undefined, /*_currentValue*/initValue);
+
+                    /*
+                        if we have an _initialValue because the setter is called with a value and the getter was never called, then we use the value passed.
+                        However after that in the setter's logic resumes, then the value passed and the value returned by this getter
+                        will now be the same, and the logic in the setter will return early.
+
+                        So in order to the system to know about the object getting an a collection value on the property, we need can have it dispatched when we put it on:
+                        if false is sent all the time, the app doesn't fully load
+                        With this as is, it does, but data is missing (directReports of person logged-in), and on further reload
+                        when we read form the FB right away, sonething wonky happens.
+                    */
+                    this._setValue(object, /*value*/initValue, /*_dispatchChange*/(_initialValue !== undefined) ? true : false, /*_initialValue*/undefined, /*_currentValue*/undefined);
                 }
             },
         },
@@ -697,7 +708,17 @@ exports.DataTrigger.prototype = Object.create(
             configurable: true,
             writable: true,
             value: function (object, value, _dispatchChange, _initialValue, _currentValue) {
-                if (object[this._privatePropertyName] === value) return;
+                //let objectPropertyValue = this._getValue(object, /*shouldFetch*/false, /*_initialValue*/value);
+                let objectPropertyValue = (arguments.length >= 5) ? _currentValue : this._getValue(object,  /*shouldFetch*/false, /*_initialValue*/value);
+                //if (object[this._privatePropertyName] === value) return;
+
+                //If objectPropertyValue - the value of the property we handle on object as we enter _setValue is the same as the one passed, then nothing to do
+                //UNLESS, UNLESS, the _currentValue arument is passed, which is what _getValue() passes when it needs to set the mutable collection 
+                //BUT when we come back from  _getValue() -> ensureValue() and this setter was the first time the property was interacted with, 
+                // ie the getter was never invoked before, then for efficiency's sake, we store the value passed in
+                // and avoid to create a new array. BUT that means that in that use case:
+                // (objectPropertyValue === value && !(arguments.length >= 5)) is true and we bail too early
+                if (objectPropertyValue === value && !(arguments.length >= 5)) return;
 
                 var status,
                     prototype,
@@ -724,11 +745,14 @@ exports.DataTrigger.prototype = Object.create(
                 //FIXME - this is way more complicated than it should...
                 //If _initialValue is null from mapping, but this.isToMany is true or if's a range, then we want  this._getValue() to call this._ensureCollectionValue() and have the proper collection set there, and observed by _getValue() calling .setValue().
                 //If _initialValue is not null from mapping and this.isToMany is true or if's a range, then we want  this._getValue() to call this._ensureCollectionValue() and have the proper collection set there, and observed by _getValue() calling .setValue().
-                if((this.isToMany || this.propertyDescriptor.collectionValueType === "range") && _initialValue !== undefined) {
-                    initialValue = this._getValue(object, shouldFetch, _initialValue);
-                } else {
-                    initialValue = arguments.length >= 4 ? _initialValue : this._getValue(object, shouldFetch, _initialValue);
-                }
+                // if((this.isToMany || this.propertyDescriptor.collectionValueType === "range") && _initialValue !== undefined) {
+                //     initialValue = this._getValue(object, shouldFetch, _initialValue);
+                // } else {
+                //     //initialValue = arguments.length >= 4 ? _initialValue : this._getValue(object, shouldFetch, _initialValue);
+                //     //initialValue = arguments.length >= 4 ? _initialValue : objectPropertyValue;
+                //     initialValue = objectPropertyValue;
+                // }
+                    initialValue = objectPropertyValue;
 
                 // initialValue = arguments.length >= 4
                 //     ? _initialValue
@@ -765,13 +789,19 @@ exports.DataTrigger.prototype = Object.create(
                              * this._getValue() sets object[this._privatePropertyName] to [] via calling this
                              */
                             if (value?.length) {
-                                // object[this._privatePropertyName].splice.apply(initialValue, [0, initialValue.length].concat(value));
-                                object[this._privatePropertyName].splice.call(
-                                    initialValue,
-                                    0,
-                                    initialValue.length,
-                                    ...value
-                                );
+
+                                //If the setter is called with a different array but identical to our instance variable, there's no point making noise
+                                if(!value.equals(object[this._privatePropertyName])) {
+
+                                    // object[this._privatePropertyName].splice.apply(initialValue, [0, initialValue.length].concat(value));
+                                    object[this._privatePropertyName].splice.call(
+                                        initialValue,
+                                        0,
+                                        initialValue.length,
+                                        ...value
+                                    );
+                                }
+
                             }
                         } else if (isMap && value) {
                             // We want to maintain the same map,
@@ -819,6 +849,9 @@ exports.DataTrigger.prototype = Object.create(
                 // addRangeChangeListener
 
                 // If we're not in the middle of a mapping...:
+                //If this.isToMany, value could be a different instance passed in
+                //but we stick to our mutable collection once we have one, in which case
+                //  currentValue should be the same as initialValue
                 if (
                     currentValue !== initialValue &&
                     dispatchChange /*&& (!this._service._objectsBeingMapped.has(object) || this._service.isObjectCreated(object))*/

--- a/data/service/data-trigger.js
+++ b/data/service/data-trigger.js
@@ -979,7 +979,7 @@ exports.DataTrigger.prototype = Object.create(
          * @returns {external:Promise}
          */
         updateObjectProperty: {
-            value: function (object) {
+            value: function (object, isUpdate = false) {
                 var self = this,
                     status = this._getValueStatus(object) || this._setValueStatus(object, {});
                 if (!status.promise) {
@@ -988,7 +988,7 @@ exports.DataTrigger.prototype = Object.create(
                         status.resolve = resolve;
                         status.reject = reject;
                     });
-                    self._fetchObjectProperty(object);
+                    self._fetchObjectProperty(object, isUpdate);
                 }
                 // Return the existing or just created promise for this data.
                 return status.promise;
@@ -1002,11 +1002,11 @@ exports.DataTrigger.prototype = Object.create(
          * @returns {external:Promise}
          */
         _fetchObjectProperty: {
-            value: function (object) {
+            value: function (object, isUpdate) {
                 var self = this;
                 //console.log("data-trigger: _fetchObjectProperty "+this._propertyName,object );
                 this._service
-                    .fetchObjectProperty(object, this._propertyName)
+                    .fetchObjectProperty(object, this._propertyName, /*isObjectCreated*/ this._service.isObjectCreated(object), isUpdate)
                     .then((propertyValue) => {
                         this._service._objectsBeingMapped.add(object);
 

--- a/data/service/data-trigger.js
+++ b/data/service/data-trigger.js
@@ -421,7 +421,7 @@ exports.DataTrigger.prototype = Object.create(
                         With this as is, it does, but data is missing (directReports of person logged-in), and on further reload
                         when we read form the FB right away, sonething wonky happens.
                     */
-                    this._setValue(object, /*value*/initValue, /*_dispatchChange*/(_initialValue !== undefined) ? true : false, /*_initialValue*/undefined, /*_currentValue*/undefined);
+                    this._setValue(object, /*value*/initValue, /*_dispatchChange*/(_initialValue && ((_initialValue.length === undefined ? _initialValue.size :_initialValue.length) > 0)) ? true : false, /*_initialValue*/undefined, /*_currentValue*/undefined);
                 }
             },
         },
@@ -862,6 +862,7 @@ exports.DataTrigger.prototype = Object.create(
                     changeEvent.key = this._propertyName;
                     changeEvent.previousKeyValue = initialValue;
                     changeEvent.keyValue = currentValue;
+                    changeEvent.propertyDescriptor = this.propertyDescriptor;
 
                     // To deal with changes happening to an array value of that property,
                     // we'll need to add/cancel observing on the array itself

--- a/data/service/data-trigger.js
+++ b/data/service/data-trigger.js
@@ -527,7 +527,16 @@ exports.DataTrigger.prototype = Object.create(
 
                             if (!listener) {
                                 listener = function _triggerArrayCollectionListener(plus, minus, index) {
-                                    if (plus?.length > 0 || minus?.length > 0) {
+                                    /*
+                                        replacing with using the new .isEmpty to eliminate arrays
+                                        that may be sparse or specifically contain undefined values.
+
+                                        Some bindings can cause some arrays in those unusual states
+
+                                        isEmpty true if an array has a length of zero or it only contains undefined values
+                                    */
+                                    //if (plus?.length > 0 || minus?.length > 0) {
+                                    if (!plus?.isEmpty || !minus?.isEmpty) {
                                         // If we're not in the middle of a mapping...:
                                         // if(!self._service._objectsBeingMapped.has(object)) {
                                         // Dispatch update event

--- a/data/service/data-trigger.js
+++ b/data/service/data-trigger.js
@@ -338,8 +338,9 @@ exports.DataTrigger.prototype = Object.create(
                 //}
 
                 // Ensure to-Many properties are initialized to their collection type.
-                this._ensureCollectionValue(object, _initialValue);
-
+                if ((this.isToMany || this.propertyDescriptor.collectionValueType !== undefined)) {
+                    this._ensureCollectionValue(object, _initialValue);
+                }
                 // Return the property's current value.
                 return this._valueGetter ? this._valueGetter.call(object) : object[this._privatePropertyName];
             },
@@ -352,9 +353,9 @@ exports.DataTrigger.prototype = Object.create(
         _ensureCollectionValue: {
             value: function _ensureCollectionValue(object, _initialValue) {
                 // When the property does not expect a collection value, nothing to do
-                if (!(this.isToMany || this.propertyDescriptor.collectionValueType !== undefined)) {
-                    return;
-                }
+                // if (!(this.isToMany || this.propertyDescriptor.collectionValueType !== undefined)) {
+                //     return;
+                // }
 
                 // Initialize to-Many to their collection type.
                 if (

--- a/data/service/data-trigger.js
+++ b/data/service/data-trigger.js
@@ -836,7 +836,9 @@ exports.DataTrigger.prototype = Object.create(
                 }
 
                 //undefined should never be set from the inside as part of the mapping as undefined is the state we expect before mapping / fetching of the value of a property
-                currentValue = (arguments.length >= 5 && _currentValue !== undefined) ? _currentValue : this._getValue(object, shouldFetch);
+                //_currentValue is only there, (arguments.length >= 5) when we're called by _getValue() -> _ensureCollectionValue(), as the first time a collection is accessed, the _currentValue would be undefined
+                //And in this case, we already assigned it to the private variable line 830, so it's value now
+                currentValue = (arguments.length >= 5) ? value : this._getValue(object, shouldFetch);
                 // currentValue = arguments.length >= 5
                 //     ? _currentValue
                 //     : (!object.snapshot && this._service.rootService._objectsBeingMapped.has(object))

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -1677,11 +1677,11 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                     Shutting down the work bellow being done in _assignInversePropertyValue() should be identical (and redundant...)
                     to what DataService's handleChange() does but, keeping it around until we don't see any issue
                 */
-                // return hasInverse 
-                //     ? self._assignInversePropertyValue(data, object, propertyDescriptor, rule, registerMappedPropertiesAsChanged).then(function() {
-                //         return data;
-                //     }) 
-                //     : data;
+                return hasInverse 
+                    ? self._assignInversePropertyValue(data, object, propertyDescriptor, rule, registerMappedPropertiesAsChanged).then(function() {
+                        return data;
+                    }) 
+                    : data;
             }
 
             function ruleEvaluationError(error) {
@@ -2871,11 +2871,11 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                         //This should move the values into the mutable collection on the object.
 
                         //3/8/26 shifting to more deliberate use of internal setter to pass more context 
-                        //return (object[propertyName] = defaultValue);
-                        propertySetter
-                            ? propertySetter.call(object, /*value*/defaultValue, /*_dispatchChange*/ true, /*_initialValue*/ defaultValue, /*_currentValue*/undefined)
-                            : (object[propertyName] = defaultValue);
-                        return defaultValue;
+                        return (object[propertyName] = defaultValue);
+                        // propertySetter
+                        //     ? propertySetter.call(object, /*value*/defaultValue, /*_dispatchChange*/ true, /*_initialValue*/ defaultValue, /*_currentValue*/undefined)
+                        //     : (object[propertyName] = defaultValue);
+                        // return defaultValue;
                     // } else {
                     //     return (object[propertyName] = defaultValue);
                     // }
@@ -2888,17 +2888,17 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                         So we need to make sure that null is properly set on the object
                     */
                     //3/8/26 shifting to more deliberate use of internal sette to pass more context 
-                    //return (object[propertyName] = value);
+                    return (object[propertyName] = value);
                     /*
                         3/8/26 - with propertyName === "accountConfirmationCode", there's no propertySetter.
                         could be because it's set as             "isSerializable": false, in the object descriptor?
 
                     */
-                    propertySetter
-                        ? propertySetter.call(object, /*value*/value, /*_dispatchChange*/ true, /*_initialValue*/ value, /*_currentValue*/undefined)
-                        : (object[propertyName] = value);
+                    // propertySetter
+                    //     ? propertySetter.call(object, /*value*/value, /*_dispatchChange*/ true, /*_initialValue*/ value, /*_currentValue*/undefined)
+                    //     : (object[propertyName] = value);
 
-                    return value;
+                    // return value;
                 } else {
                     /* We end up here if value === null and isToMany is true */
                     propertySetter
@@ -2909,11 +2909,11 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                 }
             } else {
                 //3/8/26 shifting to more deliberate use of internal setter to pass more context 
-                //return (object[propertyName] = value);
-                propertySetter
-                        ? propertySetter.call(object, /*value*/value, /*_dispatchChange*/ true, /*_initialValue*/ value, /*_currentValue*/undefined)
-                        : (object[propertyName] = value);
-                return value;
+                return (object[propertyName] = value);
+                // propertySetter
+                //         ? propertySetter.call(object, /*value*/value, /*_dispatchChange*/ true, /*_initialValue*/ value, /*_currentValue*/undefined)
+                //         : (object[propertyName] = value);
+                // return value;
             }
         }
     },

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -2022,83 +2022,38 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
     //     }
     // },
     _mapObjectPropertyToRawDataProperty: {
-        value: function(object, propertyName, data,  rawPropertyName, added, removed, _rule, lastReadSnapshot, rawDataSnapshot) {
+        value: function(object, propertyName, data,  rawPropertyName, changes, _rule, lastReadSnapshot, rawDataSnapshot) {
 
-            if((added && added.length > 0) || (removed && removed.length > 0 )) {
+            if((changes && changes.length > 0)) {
                 var tmpExtendObject,
                     //We derived object so we can pretend the value of the property is alternatively added, then removed, to get the mapping done.
                     //tmpExtendObject = Object.create(object),
-                    diffData = Object.create(null),
-                    mappedKeys,
-                    i, countI, iKey,
+                    
+                    //__mapObjectToRawDataProperty is run in parallel for added and removed so we need
+                    //to use a separate diffData for each to ensure one does not overwrite the other
+                    i, countI,
                     aPropertyChanges = {},
-                    addedResult, addedResultIsPromise,
-                    removedResult, removedResultIsPromise,
-                    requirements,
-                    result;
+                    rawChanges = [],
+                    rawChange,
+                    results, result;
 
                 data[rawPropertyName] = aPropertyChanges;
+                aPropertyChanges.changes = rawChanges;
 
-                if(added && added.length > 0) {
-                    /*
-                        Here we have a situation where in the most common case object[propertyName] is not equal to the content of added, like if there were pre-exising values.
 
-                        Since we want to only send the diff if possible (we might need to add a flag on RawDataService to know if it can handle diffs or if needs the whole thing.). If there were a notion of order in the propertyDescriptor, that might also be a reason to not send a diff.
-
-                        First we tried to use an extension of the object, but that still modifies it. So we're going to build just a payload object with the values for _rule.requirements.
-                    */
-                    requirements = _rule.requirements;
-                    tmpExtendObject = {};
-                    for(i=0, countI = requirements.length; ( i<countI); i++ ) {
-                        //added is a set, regular properties are array, not ideal but we need to convert to be able to map.
-                        tmpExtendObject[requirements[i]] = (requirements[i] === propertyName) ? added : object[requirements[i]];
-                    }
-
-                    //tmpExtendObject[propertyName] = Array.from(added);
-                    addedResult = this.__mapObjectToRawDataProperty(tmpExtendObject, diffData, rawPropertyName, _rule, lastReadSnapshot, rawDataSnapshot);
-
-                    if (this._isAsync(addedResult)) {
-                        addedResultIsPromise = true;
-                        addedResult = addedResult.then(() => {
-                            this._assignMappedDiffDataToPropertyChangesObjectKey(diffData, aPropertyChanges,"addedValues");
-                        });
-                    } else {
-                        this._assignMappedDiffDataToPropertyChangesObjectKey(diffData, aPropertyChanges,"addedValues");
-                    }
+            for(i=0, countI = changes.length; ( i<countI); i++ ) {
+                rawChange = {};
+                rawChanges.push(rawChange);
+                result = this._mapObjectChangeToRawChange(object, propertyName, rawChange,  rawPropertyName, changes[i], _rule, lastReadSnapshot, rawDataSnapshot);
+                if (this._isAsync(result)) {
+                    results = results || [];
+                    results.push(result);
                 }
+            }
 
-                if(removed && removed.length > 0 ) {
-
-                    requirements = (requirements || _rule.requirements);
-                    // tmpExtendObject[propertyName] = Array.from(result);
-                    tmpExtendObject = (tmpExtendObject || {});
-
-                    for(i=0, countI = requirements.length; ( i<countI); i++ ) {
-                        //added is a set, regular properties are array, not ideal but we need to convert to be able to map.
-                        tmpExtendObject[requirements[i]] = (requirements[i] === propertyName) ? removed : object[requirements[i]];
-                    }
-
-                    removedResult = this.__mapObjectToRawDataProperty(tmpExtendObject, diffData, rawPropertyName, _rule, lastReadSnapshot, rawDataSnapshot);
-
-                    if (this._isAsync(removedResult)) {
-                        removedResultIsPromise = true;
-                        removedResult = removedResult.then(() => {
-                            this._assignMappedDiffDataToPropertyChangesObjectKey(diffData, aPropertyChanges,"removedValues");
-                        });
-                    } else {
-                        this._assignMappedDiffDataToPropertyChangesObjectKey(diffData, aPropertyChanges,"removedValues");
-                    }
-                }
-
-                if(addedResultIsPromise && removedResultIsPromise) {
-                    return Promise.all([addedResult, removedResult]);
-                } else if(addedResultIsPromise) {
-                    return addedResult;
-                } else if(removedResultIsPromise) {
-                    return removedResult;
-                }
-
-                return;
+            if (results) {
+                return Promise.all(results);
+            }
 
             } else {
                 return this.__mapObjectToRawDataProperty(object, data, rawPropertyName, _rule, lastReadSnapshot, rawDataSnapshot);
@@ -2106,16 +2061,78 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
         }
     },
 
-    _assignMappedDiffDataToPropertyChangesObjectKey: {
-        value: function(diffData, aPropertyChanges, key /* addedValues/removedValues*/) {
-            var mappedKeys = Object.keys(diffData),
-                i, countI;
+    _mapObjectChangeToRawChange: {
+        value: function (object, propertyName, data,  rawPropertyName, change, _rule, lastReadSnapshot, rawDataSnapshot) {
+            var tmpExtendObject,
+                    //We derived object so we can pretend the value of the property is alternatively added, then removed, to get the mapping done.
+                    //tmpExtendObject = Object.create(object),
+                    
+                    i, countI,
+                    addedResult,
+                    removedResult,
+                    requirements,
+                    //__mapObjectToRawDataProperty is run in parallel for added and removed so we need
+                    //to use a separate diffData for each to ensure one does not overwrite the other
+                    diffDataAdded,
+                    diffDataRemoved;
 
-            for(i=0, countI = mappedKeys.length; (i <countI); i++) {
-                aPropertyChanges[key] = diffData[mappedKeys[i]];
-            }
+                if (change.addedValues && change.addedValues.length) {
+                    tmpExtendObject = {};
+
+                
+                    requirements = (requirements || _rule.requirements);
+
+                    for(i=0, countI = requirements.length; ( i<countI); i++ ) {
+                        //added is a set, regular properties are array, not ideal but we need to convert to be able to map.
+                        tmpExtendObject[requirements[i]] = requirements[i] === propertyName ? change.addedValues : object[requirements[i]];
+                    }
+                    diffDataAdded = {};
+                    addedResult = this.__mapObjectToRawDataProperty(tmpExtendObject, diffDataAdded, rawPropertyName, _rule, lastReadSnapshot, rawDataSnapshot);
+
+                    if (this._isAsync(addedResult)) {
+                        addedResult = addedResult.then(function () {
+                            data.addedValues = diffDataAdded[rawPropertyName];
+                            data.index = change.index;
+                        });
+                    } else {
+                        data.addedValues = diffDataAdded[rawPropertyName];
+                        data.index = change.index;
+                    }
+                } 
+
+                if (change.removedValues && change.removedValues.length) {
+                    tmpExtendObject = {};
+
+                
+                    requirements = (requirements || _rule.requirements);
+
+                    for(i=0, countI = requirements.length; ( i<countI); i++ ) {
+                        //added is a set, regular properties are array, not ideal but we need to convert to be able to map.
+                        tmpExtendObject[requirements[i]] = requirements[i] === propertyName ? change.removedValues : object[requirements[i]];
+                    }
+                    diffDataRemoved = {};
+                    removedResult = this.__mapObjectToRawDataProperty(tmpExtendObject, diffDataRemoved, rawPropertyName, _rule, lastReadSnapshot, rawDataSnapshot);
+
+                    if (this._isAsync(removedResult)) {
+                        removedResult = removedResult.then(function () {
+                            data.removedValues = diffDataRemoved[rawPropertyName];
+                            data.index = change.index;
+                        });
+                    } else {
+                        data.removedValues = diffDataRemoved[rawPropertyName];
+                        data.index = change.index;
+                    }
+                }
+
+
+                return Promise.all([addedResult, removedResult]).then(function (result) {
+                    data, propertyName, rawPropertyName, object;
+                    return result;
+                })
+
         }
     },
+
 
     __mapObjectToRawDataProperty: {
         value: function(object, data, propertyName, _rule, lastReadSnapshot, rawDataSnapshot) {
@@ -2170,7 +2187,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
 
 
     _mapObjectPropertyToRawDataWithRule: {
-        value: function(object, propertyName, data, added, removed, rule, lastReadSnapshot, rawDataSnapshot) {
+        value: function(object, propertyName, data, changes, rule, lastReadSnapshot, rawDataSnapshot) {
 
             /*
                 If the objectRule.sourcePath isn't part of our own primary key
@@ -2189,10 +2206,10 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
             if (this._isAsync(result)) {
                 result = result.then(function (value) {
                     //console.log("_mapObjectPropertyToRawDataProperty "+object.constructor.name+" - "+propertyName);
-                    return self._mapObjectPropertyToRawDataProperty(object, propertyName, data, rawDataProperty, added, removed, rule, lastReadSnapshot, rawDataSnapshot);
+                    return self._mapObjectPropertyToRawDataProperty(object, propertyName, data, rawDataProperty, changes, rule, lastReadSnapshot, rawDataSnapshot);
                 });
             } else {
-                result = this._mapObjectPropertyToRawDataProperty(object, propertyName, data, rawDataProperty, added, removed, rule, lastReadSnapshot, rawDataSnapshot);
+                result = this._mapObjectPropertyToRawDataProperty(object, propertyName, data, rawDataProperty, changes, rule, lastReadSnapshot, rawDataSnapshot);
             }
 
             //using delegation to allow dataService customization
@@ -2210,7 +2227,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
     },
 
     mapObjectPropertyToRawData: {
-        value: function(object, propertyName, data, context, added, removed, lastReadSnapshot, rawDataSnapshot) {
+        value: function(object, propertyName, data, context, changes, lastReadSnapshot, rawDataSnapshot) {
             var objectRule = this.objectMappingRuleForPropertyName(propertyName),
             rawDataMappingRules,
             rawDataProperty;
@@ -2236,7 +2253,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                             iPreviousPromise = result;
                         }
 
-                        result = this._mapObjectPropertyToRawDataWithRule(object, propertyName, data, added, removed, rule, lastReadSnapshot, rawDataSnapshot);
+                        result = this._mapObjectPropertyToRawDataWithRule(object, propertyName, data, changes, rule, lastReadSnapshot, rawDataSnapshot);
 
                         if (this._isAsync(result)) {
                             if(iPreviousPromise) {

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -338,7 +338,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
     },
     rawDataTypeIdentificationCriteria: {
         get: function() {
-            return this._rawDataTypeIdentificationCriteria || this.service.defaultOwnRawDataTypeIdentificationCriteriaForObjectDescriptor(this.objectDescriptor);
+            return this._rawDataTypeIdentificationCriteria || this.service.rawDataTypeIdentificationCriteriaForType(this.objectDescriptor);
         },
         set: function(value) {
             if(this._rawDataTypeIdentificationCriteria !== value) {
@@ -497,7 +497,8 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
         get: function() {
             if(!this._objectPropertyNames) {
 
-                this._objectPropertyNames = Object.keys(this.objectMappingRules);
+                //We want to capture all keys, owned + inherited
+                this._objectPropertyNames = Object.allKeys(this.objectMappingRules);
                 // let objectMappingRules = this.objectMappingRules,
                 // i, countI,
                 // _objectPropertyNames = [];
@@ -1204,8 +1205,52 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
         }
     },
 
+    /**
+     * For every raw property involved in the rule, we assess the value between data and snapshot
+     *
+     * @method
+     * @argument {Object} data - fetched raw data
+     * @argument {MappingRule} aRule - A rule considered
+     * @argument {Object} object - the object being mapped - if we need to assess wether it has changes or not. Or should we do that later in the process?
+     * @argument {Object} snapshot - the snapshot of the object being mapped
+     * @argument {Boolean} refreshesRefetchedInstances - refreshesRefetchedInstances
+     *                                      
+     * @returns {Boolean} 
+     *
+     */
+    _shouldMapRawDataWithRuleToObjectWithSnapshot: {
+        value: function(data, aRule, object, snapshot, refreshesRefetchedInstances) {
+            let aRuleRequirements = aRule.requirements,
+                equals = Object.equals;
+
+            for(let i=0, countI = aRuleRequirements.length; (i<countI); i++) {
+                let iRuleRequirement = aRuleRequirements[i],
+                    // evaluatedDataValue = aRule.evaluate(data),
+                    // evaluatedSnapshotValue = aRule.evaluate(data),
+                    // lookedUpDataValue = data[aRule.sourcePath],
+                    // lookedUpSnapshotValue = snapshot[aRule.sourcePath];
+                    dataValue = data[iRuleRequirement],
+                    snapshotValue = snapshot[iRuleRequirement];
+
+                /*
+                    We've fetched a value that is the same as we did before. so there shouldn't be anything to do?
+                    IF there are unsaved changes, then we also avoid to override it by re-mapping the value and re-set it on object.
+
+                    But if the DataQuery that initiated this has refreshesRefetchedInstances === true,
+                    then we should go ahead and proceed
+                */
+                if(equals(dataValue,snapshotValue) && !refreshesRefetchedInstances) {
+                    return false;
+                }
+
+            }
+            return true;
+        }
+    },
+
     _mapRawDataPropertiesToObject: {
-        value: function(data, object, context, readExpressions, mappingScope, unmappedRequisitePropertyNames, promises, mappedProperties, registerMappedPropertiesAsChanged) {
+        value: function(data, object, context, readExpressions, mappingScope, unmappedRequisitePropertyNames, promises, mappedProperties, registerMappedPropertiesAsChanged, snapshot) {
+                      
             var rawDataProperties = data ? Object.keys(data) : null,
                 result,
                 rawDataPropertyIteration = 0, rawDataPropertyIterationCount = (rawDataProperties?.length || 0),
@@ -1221,7 +1266,12 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                 dataHasRuleRequirements,
                 isObjectCreated = service.isObjectCreated(object),
                 changesForDataObject,
-                mainService;
+                mainService,
+                //We have some serious discrepancies here to sortout... most of that in mappingScope, which is much more legible
+                readCompletedOperation = context instanceof DataOperation
+                    ? context
+                    : mappingScope.root.child.value, 
+                refreshesRefetchedInstances = !!readCompletedOperation.referrer.dataStream?.query.refreshesRefetchedInstances;
 
             /*
                 If data is null and we have readExpressions, which are object-level, we go on and set those.
@@ -1332,6 +1382,16 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                         }
 
                         /*
+                            If there's a snapshot, we're going to avoid doing anything if the value of the snapshot
+                            match the current raw data, and the object doesn't have the property named as aRule.targetPath set. 
+                            But there shouldn't be a fetch if the property could have been mapped from the existing snapshot, 
+                            unless it was explicity requested a refresh with mainService.updateObjectProperties()
+                        */
+                        if(snapshot && !this._shouldMapRawDataWithRuleToObjectWithSnapshot(data, aRule, object, snapshot, refreshesRefetchedInstances)) {
+                            continue;
+                        }
+
+                        /*
                             Tell our service: mappingWillMapRawDataToObjectProperty
                         */
                         service.mappingWillMapRawDataToObjectProperty(this, data, object, aRule.targetPath, context, mappingScope);
@@ -1419,7 +1479,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
     // 4. 
 
     mapRawDataToObject: {
-        value: function (rawData, object, context, readExpressions, mappedProperties, registerMappedPropertiesAsChanged) {
+        value: function (rawData, object, context, readExpressions, mappedProperties, registerMappedPropertiesAsChanged, snapshot) {
             var promises,
                 requisitePropertyNames = this.requisitePropertyNames,
                 unmappedRequisitePropertyNames = new Set(requisitePropertyNames),
@@ -1429,8 +1489,11 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
             if(context instanceof DataOperation) {
                 mappingScope = this._scope.nest(context);
                 mappingScope = mappingScope.nest(rawData);
-            } else {
+            } else if (!(context instanceof Scope)) {
                 mappingScope = this._scope.nest(rawData);
+            } else {
+                mappingScope = context;
+                mappingScope = mappingScope.nest(rawData);
             }
 
             mappingScope.rootObjectBeingMapped = object;
@@ -1441,7 +1504,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
             */
             _rawData = this.service.mappingWillMapRawDataToObject(this, rawData, object, context, readExpressions, mappingScope)
 
-            promises = this._mapRawDataPropertiesToObject(_rawData, object, context, readExpressions, mappingScope, unmappedRequisitePropertyNames, promises, mappedProperties, registerMappedPropertiesAsChanged);
+            promises = this._mapRawDataPropertiesToObject(_rawData, object, context, readExpressions, mappingScope, unmappedRequisitePropertyNames, promises, mappedProperties, registerMappedPropertiesAsChanged, snapshot);
             
             /*
                 This is causing problems: as partial aspects of the object are filled-in, the attempts to run mapping rules for object properties on raw data that doesn't contain
@@ -3305,15 +3368,37 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
 
     _mapObjectMappingRuleForPropertyName: {
         value: function (rawRule, propertyName, objectMappingRules, rawDataMappingRules) {
-            if(!rawRule) {
-                if(this.rawDataPrimaryKeys.indexOf(propertyName) !== -1) {
-                    objectMappingRules[propertyName] = null;
-                } else if(objectMappingRules[propertyName] === undefined) {
-                    //console.warn("ExpressionDataMapping _mapObjectMappingRuleForPropertyName(): no rule found for propertyName '"+propertyName+"'");
-                    objectMappingRules[propertyName] = null;
-                }
-            } else {
-                var rule;
+
+            /*
+                Keeping former implementation around for buffering possible regression.
+                The reason this is causing bugs is that it's being called with rawRule being falsy, because that mapping doesn't have such property,
+                which happens when the mapping of subclasses go up the chain looking for a rule, that might be missing.
+                The commented out implementation has the side effect of adding propertyName to objectMappingRules - this._objectMappingRules, and later
+                when we grab all keys to treat them as read expressions, then we end up with things that don't exist and polute, with side-effects.
+            */
+            // if(!rawRule) {
+            //     if(this.rawDataPrimaryKeys.indexOf(propertyName) !== -1) {
+            //         objectMappingRules[propertyName] = null;
+            //     } else if(objectMappingRules[propertyName] === undefined) {
+            //         //console.warn("ExpressionDataMapping _mapObjectMappingRuleForPropertyName(): no rule found for propertyName '"+propertyName+"'");
+            //         objectMappingRules[propertyName] = null;
+            //     }
+            // } else {
+            //     var rule;
+
+            //     if (this._shouldMapRule(rawRule, true)) {
+            //         rule = this.makeRuleFromRawRule(rawRule, propertyName, true, true);
+            //         objectMappingRules[rule.targetPath] = rule;
+            //     }
+
+            //     if (this._shouldMapRule(rawRule, false)) {
+            //         rule = this.makeRuleFromRawRule(rawRule, propertyName, false, true);
+            //         rawDataMappingRules[rule.targetPath] = rule;
+            //     }
+            // }
+
+            if(rawRule) {
+                let rule;
 
                 if (this._shouldMapRule(rawRule, true)) {
                     rule = this.makeRuleFromRawRule(rawRule, propertyName, true, true);
@@ -3325,6 +3410,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                     rawDataMappingRules[rule.targetPath] = rule;
                 }
             }
+
         }
     },
 

--- a/data/service/expression-data-mapping.js
+++ b/data/service/expression-data-mapping.js
@@ -2867,7 +2867,7 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
     _assignObjectValueOrDefault: {
         value: function _assignObjectValueOrDefault(object, propertyName, value, propertyDescriptor) {
             const hasValue = typeof value !== "undefined" && value !== null;
-            let propertySetter = Object.getPropertyDescriptor(object, propertyName).set;
+            // let propertySetter = Object.getPropertyDescriptor(object, propertyName).set;
 
             if (!hasValue) { 
 
@@ -2918,11 +2918,11 @@ exports.ExpressionDataMapping = DataMapping.specialize(/** @lends ExpressionData
                     // return value;
                 } else {
                     /* We end up here if value === null and isToMany is true */
-                    propertySetter
-                        ? propertySetter.call(object, /*value*/value, /*_dispatchChange*/ true, /*_initialValue*/ value, /*_currentValue*/undefined)
-                        : (object[propertyName] = value);
+                    // propertySetter
+                    //     ? propertySetter.call(object, /*value*/value, /*_dispatchChange*/ true, /*_initialValue*/ value, /*_currentValue*/undefined)
+                    //     : (object[propertyName] = value);
 
-                    return value;
+                    return (object[propertyName] = value);
                 }
             } else {
                 //3/8/26 shifting to more deliberate use of internal setter to pass more context 

--- a/data/service/mux/mux-data-service.js
+++ b/data/service/mux/mux-data-service.js
@@ -31,4 +31,14 @@ exports.MuxDataService = class MuxDataService extends RawDataService {/** @lends
         
     }
 
+    /**
+     * Mux RawDataServices orchestrate the work of other concrete RawDataServices, they won't have a connection of their own
+     *
+     * @property
+     *
+     */
+    get connection() {
+        return null;
+    }
+
 }

--- a/data/service/mux/synchronization-data-service.js
+++ b/data/service/mux/synchronization-data-service.js
@@ -380,7 +380,10 @@ exports.SynchronizationDataService = class SynchronizationDataService extends Mu
         }
         this.startTrackingChangesForObjectBeingMapped(rootObject);
         if (propertyDescriptor.cardinality === Infinity) {
-            changeEvent.addedValues.forEach((nestedObject) => {
+            let changedValues = changeEvent.addedValues ? changeEvent.addedValues : changeEvent.keyValue;
+
+            //We would ideally not use a forEach for frugality's sake
+            changedValues.forEach((nestedObject) => {
                 if (nestedObject && propertyDescriptor._valueDescriptorReference) {
                     this._logTypeEvent(nestedObject.objectDescriptor, `${nestedObject.dataIdentifier.dataService.name} Register ${nestedObject.objectDescriptor.name} as a nested object via ${rootObject.objectDescriptor.name}.${changeEvent.key} - ${rootObject.dataIdentifier ? rootObject.dataIdentifier.primaryKey : "no primary key"}`)
                 }

--- a/data/service/mux/synchronization-data-service.js
+++ b/data/service/mux/synchronization-data-service.js
@@ -324,6 +324,15 @@ exports.SynchronizationDataService = class SynchronizationDataService extends Mu
                 }
 
             } 
+
+        /*
+         FIXME: this._isValueForChangeEventBeingTracked(changeEvent) is evaluating to true for objects after they are synced which means those objects
+         are not being cleaned up correctly. 
+
+         Example: The change event for Person.preferredNextRoles. 
+         By the time a user is selecting a preferredNextRole, the value on the event (a JobRole)  
+         should already be synced. 
+        */
         } else if (this._isValueForChangeEventBeingTracked(changeEvent)) {
                 if (propertyDescriptor._valueDescriptorReference) {
                     this._logTypeEvent(dataObject.objectDescriptor, `registerChangedObject ADD SYNC ${changeEvent.keyValue ? 'Object' : 'Array'}`, dataObject.dataIdentifier.dataService.name, dataObject.dataIdentifier.primaryKey, dataObject.objectDescriptor.name, changeEvent.key, changeEvent);

--- a/data/service/mux/synchronization-data-service.js
+++ b/data/service/mux/synchronization-data-service.js
@@ -345,12 +345,17 @@ exports.SynchronizationDataService = class SynchronizationDataService extends Mu
     }
 
     _isValueForChangeEventBeingTracked(changeEvent) {
-        if (changeEvent.keyValue) {
+        if (changeEvent.propertyDescriptor.cardinality === 1) {
             return this._isSyncingOrBeingTrackedWhileMapping(changeEvent.keyValue);
-        } else if (changeEvent.addedValues) {
-            let isTracking = false, i, n;
-            for (i = 0, n = changeEvent.addedValues.length; i < n && !isTracking; i++) {
-                isTracking = this._isSyncingOrBeingTrackedWhileMapping(changeEvent.addedValues[i]);
+        } else {
+            /*
+                TODO: Support for more than Array, DataTrigger also handles collections that are Map, Set, Range
+                which need to be handled as well 
+            */
+            let changeValues = changeEvent.addedValues ? changeEvent.addedValues : changeEvent.keyValue,
+                isTracking = false, i, n;
+            for (i = 0, n = changeValues?.length; i < n && !isTracking; i++) {
+                isTracking = this._isSyncingOrBeingTrackedWhileMapping(changeValues[i]);
             }
             return isTracking;
         }
@@ -374,12 +379,12 @@ exports.SynchronizationDataService = class SynchronizationDataService extends Mu
     }
 
     startTrackingNestedObjectsForChangeEvent(rootObject, changeEvent) {
-        let propertyDescriptor = rootObject.objectDescriptor.propertyDescriptorsByName.get(changeEvent.key);
+        let propertyDescriptor = changeEvent.propertyDescriptor;
         if (!this._canTrackPropertyForChangeEvent(rootObject, changeEvent)) {
             return;
         }
         this.startTrackingChangesForObjectBeingMapped(rootObject);
-        if (propertyDescriptor.cardinality === Infinity) {
+        if (propertyDescriptor.cardinality > 1) {
             let changedValues = changeEvent.addedValues ? changeEvent.addedValues : changeEvent.keyValue;
 
             //We would ideally not use a forEach for frugality's sake

--- a/data/service/mux/synchronization-data-service.js
+++ b/data/service/mux/synchronization-data-service.js
@@ -1593,7 +1593,7 @@ exports.SynchronizationDataService = class SynchronizationDataService extends Mu
             The type at the end of an expression for relationships, complex expressions or derived properties
         */
         return this.handlesType(anObjectDescriptor)
-                ? this.readCompletionOperationReadOperationAndObjectDescriptorTarget(aReadOperation, anObjectDescriptor).length === this.childServicesHandlingDataOperationTypeForType(aReadOperation.type, anObjectDescriptor).length
+                ? this.readCompletionOperationReadOperationAndObjectDescriptorTarget(aReadOperation, anObjectDescriptor)?.length === this.childServicesHandlingDataOperationTypeForType(aReadOperation.type, anObjectDescriptor)?.length
                 : true;
     }
 

--- a/data/service/mux/synchronization-data-service.js
+++ b/data/service/mux/synchronization-data-service.js
@@ -1517,6 +1517,9 @@ exports.SynchronizationDataService = class SynchronizationDataService extends Mu
     
                 readCompletedOperation.referrer.stopImmediatePropagation();
 
+                //Cleanup
+                this.unregisterReadOperation(readCompletedOperation.referrer);    
+
             }
             
         } else if(readCompletedOperation.rawDataService === this.destinationDataService) {

--- a/data/service/mux/synchronization-data-service.js
+++ b/data/service/mux/synchronization-data-service.js
@@ -1399,10 +1399,11 @@ exports.SynchronizationDataService = class SynchronizationDataService extends Mu
 
                 if there was only one data service that handled the read operation and was our destination service, then there's no point trying anything else
             */
-           if(!this.didAllChildServicesCompletedReadOperationForTarget(readCompletedOperation.referrer, readCompletedOperation.target)) {
+           //if(!this.didAllChildServicesCompletedReadOperationForTarget(readCompletedOperation.referrer, readCompletedOperation.target)) {
+           if(!this.didAllChildServicesCompletedReadOperationForTarget(readCompletedOperation.referrer, readCompletedOperation.referrer.target)) {
 
                 /* if this readCompletedOperation doesn't come from our destinationDataService: */
-                if(((this.readCompletionOperationReadOperationAndObjectDescriptorTarget(readCompletedOperation.referrer, readCompletedOperation.target).length === 1) && (readCompletedOperation.rawDataService === this.destinationDataService))) {
+                if(((this.readCompletionOperationReadOperationAndObjectDescriptorTarget(readCompletedOperation.referrer, readCompletedOperation.referrer.target).length === 1) && (readCompletedOperation.rawDataService === this.destinationDataService))) {
                     /* Origin Services need to have a shot, so we stop propagatiom of that readCompletedOperation from our destinationService, in order to have the readOperation continue to our oriin data services: */
                     readCompletedOperation.stopPropagation();
 
@@ -1612,11 +1613,11 @@ exports.SynchronizationDataService = class SynchronizationDataService extends Mu
 
     registerChildDataServiceReadCompletionOperation(aReadCompletionOperation) {
 
-        if(aReadCompletionOperation.rawDataService.handlesDataOperationTypeForType(aReadCompletionOperation.type, aReadCompletionOperation.target)) {
+        if(aReadCompletionOperation.rawDataService.handlesDataOperationTypeForType(aReadCompletionOperation.referrer.type, aReadCompletionOperation.referrer.target)) {
             let readCompletionOperationByChildDataService = this.readCompletionOperationByTargetForReadOperation(aReadCompletionOperation.referrer),
-                readCompletionOperations = readCompletionOperationByChildDataService.get(aReadCompletionOperation.target);
+                readCompletionOperations = readCompletionOperationByChildDataService.get(aReadCompletionOperation.referrer.target);
             if(!readCompletionOperations) {
-                readCompletionOperationByChildDataService.set(aReadCompletionOperation.target, (readCompletionOperations = []));    
+                readCompletionOperationByChildDataService.set(aReadCompletionOperation.referrer.target, (readCompletionOperations = []));    
             }
             readCompletionOperations.push(aReadCompletionOperation);    
         } else {

--- a/data/service/raw-data-service.js
+++ b/data/service/raw-data-service.js
@@ -1184,7 +1184,7 @@ RawDataService.addClassProperties({
                 We need to find which rawDataTypeIdentificationCriteria evaluation returns true for rawData
                 We'll need to find a way to optimize down to a single lookup if we can
             */
-           if (this.needsRawDataTypeIdentificationCriteria) {
+           if (this.needsRawDataTypeIdentificationCriteriaForType(type)) {
                 type = this.objectTypeForRawData(type, rawData);
            }
 
@@ -1422,8 +1422,10 @@ RawDataService.addClassProperties({
         }
     },
 
-    needsRawDataTypeIdentificationCriteria: {
-        value: false
+    needsRawDataTypeIdentificationCriteriaForType: {
+        value: function(type) {
+            return this.mappingForType(type)?.needsRawDataTypeIdentificationCriteria || false
+        }
     },
 
     objectTypeForRawData: {
@@ -2357,7 +2359,10 @@ RawDataService.addClassProperties({
 
                 this._objectsBeingMapped.add(object);
 
-                result = mapping.mapRawDataToObject(record, object, context, readExpressions, mappedProperties, registerMappedPropertiesAsChanged);
+                /*
+                    We only want to pass the snapshot if it's pre-existing record. If they are equal, it means the record was recorded as the snapshot before we got here
+                */
+                result = mapping.mapRawDataToObject(record, object, context, readExpressions, mappedProperties, registerMappedPropertiesAsChanged, snapshot === record ? null : snapshot);
 
                 //Recording snapshot even if we already had an object
                 //Record snapshot before we may create an object
@@ -2488,9 +2493,9 @@ RawDataService.addClassProperties({
                 return mapping.mapObjectTypeToRawData(object, rawData, context);
             }
 
-            if(this.needsRawDataTypeIdentificationCriteria) {
+            if(this.needsRawDataTypeIdentificationCriteriaForType(object.objectDescriptor)) {
                 // debugger;
-                let criteria = this.defaultOwnRawDataTypeIdentificationCriteriaForObjectDescriptor(object.objectDescriptor);
+                let criteria = this.rawDataTypeIdentificationCriteriaForType(object.objectDescriptor);
                 
                 assign(rawData, criteria.expression, true, criteria.parameters);
             }

--- a/data/service/raw-data-service.js
+++ b/data/service/raw-data-service.js
@@ -1685,9 +1685,8 @@ RawDataService.addClassProperties({
                 return rawData
             } else {
                 var rawDataKeys = Object.keys(rawData),
-                    i, countI, iUpdatedRawDataValue, iCurrentRawDataValue, iDiffValues, iRemovedValues,
+                    i, countI, iUpdatedRawDataValue, iCurrentRawDataValue, iDiffValues,
                     iHasAddedValues, iHasRemovedValues,
-                    j, countJ, jDiffValue, jDiffValueIndex,
                     canRemoveRawDataKey;
 
                 for (i = 0, countI = rawDataKeys.length; (i < countI); i++) {

--- a/data/service/raw-data-service.js
+++ b/data/service/raw-data-service.js
@@ -1,4 +1,5 @@
-var DataService = require("./data-service").DataService,
+var Montage = require("core/core").Montage,
+    DataService = require("./data-service").DataService,
     assign = require("../../../core/frb/assign"),
     compile = require("../../core/frb/compile-evaluator"),
     Criteria = require("../../core/criteria").Criteria,
@@ -8,7 +9,6 @@ var DataService = require("./data-service").DataService,
     UserIdentity = require("../model/app/user-identity").UserIdentity,
     Deserializer = require("../../core/serialization/deserializer/montage-deserializer").MontageDeserializer,
     Map = require("../../core/collections/map"),
-    //Montage = (require) ("../../core/core").Montage,
     parse = require("../../core/frb/parse"),
     Scope = require("../../core/frb/scope"),
     deprecate = require("../../core/deprecate"),
@@ -54,6 +54,28 @@ require("../../core/collections/shim-object");
  * @extends DataService
  */
 const RawDataService = exports.RawDataService = class RawDataService extends DataService {/** @lends RawDataService */
+
+    static {
+
+        Montage.defineProperties(this.prototype, {
+            /**
+             * A criteria to be used if an instance of identity needs to be fetched.
+             *
+             * @property {Criteria} value
+             * @default null
+             */
+            identityCriteria: { value: null},
+
+            /**
+             * A DataQuery instance to be used if an instance of identity needs to be fetched.
+             *
+             * @property {DataQuery} value
+             * @default null
+             */
+            _identityQuery: { value: null}
+        });
+    }
+
 
     constructor() {
         super();
@@ -119,7 +141,175 @@ const RawDataService = exports.RawDataService = class RawDataService extends Dat
      */
 
     handleReadOperation(readOperation) {
-        
+
+        /*
+            This gives a chance to the delegate to do something async by returning a Promise from rawDataServiceWillHandleReadOperation(readOperation).
+            When that promise resolves, then we check if readOperation.defaultPrevented, if yes, the we don't handle it, otherwise we proceed.
+
+            Wonky, WIP: needs to work without a delegate actually implementing it.
+            And a RawDataService shouldn't know about all that boilerplate
+
+            Note: If there was a default delegate shared that would implement rawDataServiceWillHandleReadOperation by returning Promise.resolve(readOperation)
+            it might be simpler, but probably a bit less efficient
+
+        */
+        let readOperationCompletionPromise = this.callDelegateMethod("rawDataServiceWillHandleReadOperation", this, readOperation);
+        if (readOperationCompletionPromise) {
+            readOperationCompletionPromise = readOperationCompletionPromise.then((readOperation) => {
+                if (!readOperation.defaultPrevented) {
+                    let resultPromise = this._handleReadOperation(readOperation);
+                    if (this.promisesReadCompletionOperation) {
+                        return resultPromise
+                    }
+                }
+            });
+        } else {
+            let resultPromise = this._handleReadOperation(readOperation);
+            if (this.promisesReadCompletionOperation) {
+                readOperationCompletionPromise = resultPromise;
+            }
+        }
+
+        //If we've been asked to return a promise for the read Completion Operation, we do so. Again, this is fragile. IT HAS TO MOVE UP TO RAW DATA SERVICE
+        //WE CAN'T RELY ON INDIVIDUAL DATA SERVICE IMPLEMENTORS TO KNOW ABOUT THAT...
+        if (this.promisesReadCompletionOperation) {
+            return readOperationCompletionPromise;
+        }
+
+    }
+
+
+    /**
+     * A RawDataService needs an identity to get some kind of access credentials to present to an endpoint.
+     * A data operation can carries a user's, client's or agent's identity, but RawDataService, execuded in the backend may have an identity assigned to it
+     * 
+     * @method
+     * @argument {DataOperation} dataOperation - an instance of DataOperation
+     * @returns {Promise<Identity>} - a Promise for the identity to be used to handle the instance of DataOperation argument
+     */
+    identityForDataOperation(dataOperation) {
+        let identityPromise;
+
+        /*
+            Wether one was assigned straight or already obtained via fetchIdentity()
+        */
+        if (this.identity || this.identityQuery) {
+            return this.identityPromise;
+        } else if (dataOperation.identity) {
+            return Promise.resolve(dataOperation.identity);
+        } else if (this.application.identity) {
+            return Promise.resolve(this.application.identity);
+        } else {
+            /*
+                Workareound: readOperation.identity is undefine right now, so we're defaulting to application.identity
+                BUT #TODO: a user-mod / end-mod can evenually have multiple user identities from different identity providers
+                So we'll need to redesign for that. A RawDataService will need to figure out, which one of those user identities
+                the one it should use.
+
+                Knowing about a RawDataService's organization behind it should help match it 
+                to one of the existing identities's provider / oranization, if it's the same, but some API can accept
+                identities from multiple providers, so we need to add to RawDataService the knowledge of 
+                what kind of identities it can accept / work with:
+
+                - a criteria or a list of criteria to evaluate on identities, such that if the evaluation returns true
+                the identity can be used by the raw data service
+
+            */
+            let userIdentityQuery = DataQuery.withTypeAndCriteria(UserIdentity);
+
+
+            identityPromise = this.mainService.fetchData(userIdentityQuery);
+
+        }
+
+        return identityPromise;
+    }
+
+    _handleReadOperation(readOperation) {
+        let readOperationCompletionPromiseResolvers, readOperationCompletionPromise, readOperationCompletionPromiseResolve, readOperationCompletionPromiseReject;
+
+        if (this.promisesReadCompletionOperation) {
+            readOperationCompletionPromiseResolvers = Promise.withResolvers();
+            readOperationCompletionPromise = readOperationCompletionPromiseResolvers.promise;
+            readOperationCompletionPromiseResolve = readOperationCompletionPromiseResolvers.resolve;
+            readOperationCompletionPromiseReject = readOperationCompletionPromiseResolvers.reject;
+        } else {
+            readOperationCompletionPromise = readOperationCompletionPromiseResolve = readOperationCompletionPromiseReject = undefined;
+        }
+
+        /*
+            Here goes the core business:
+
+            1. Authenticating the RawReadOperation:
+                HTTPService uses authenticationPolicy, and logic to get an identity for that readOperation. a Promise to Authenticate / get what we need to send a RawDataOperation/RawReadOperation (an HTTP Requet, a SQL statement to a DB, etc...)
+                    So a identityForReadOperation() method would help factor that out.
+                But PG Service uses 
+        */
+
+        let identityPromise = this.identityForDataOperation(readOperation)
+
+
+        /*
+            2. Authorizing the RawReadOperation
+                HTTPService calls this.accessTokenForIdentity(resolvedIdentity), a RawDataServiceMethod that returns a cached AccessToken. The code to get it is in HttpService _handleReadOperation(), it should move out 
+                HTTPService builds a DataQuery to fetch an instance of this.accessTokenDescriptor with that identity. The property accessTokenDescriptor gives a subclass the ability to control / specialize it.
+
+                PGService uses a Secret, not an access token. In local we provide the secret direclty, otherwise we configure the secretName and PGService builds a DataQuery to fetch a Secret with that name.
+                So in the end, both of these services have to fetch a data instance of a certain type matching a criteria that will allow them to connect to the RawService endpoint, and to authenticate to it.
+
+                Promise<AccessCredential> accessCredentialsForIdentity()
+                // Promise<AccessCredential> accessCredentialsPromiseForIdentity()
+
+            3. Connecting: where + auth
+                HTTPService uses properties like :
+                    "baseURL": "https://api.endpoint.vendor.com",
+                    "issuerURI": "https://api.endpoint.vendor.com/adfs/oauth2/token",
+
+                    In the end, the token is attached to the Request, built from the connection info like baseURL, then sent
+
+                PGService uses those connection info configured per environment                   
+                
+                    "environment": "local",
+                    "database": "projectName",
+                    "owner": "postgres",
+                    "schema": "projectName_v1"
+
+                and adds the URL to the host AND auth info (username, passwords, certificates) read from the stored secret
+                to establish a connection before sending the "raw request" aka query aka SQL statement
+
+            4. All of this is true for any one or many rawReadOperation(s) derived from readOperation
+
+        */
+
+
+        return readOperationCompletionPromise;
+    }
+
+    /**
+     * Gives the opportunity to turn one dataOperation into multiple Raw Data Operations if needed by a service's practical constraints. 
+     * an HTTP service may need multiple HTTP Requests, a SQL Service multiple SQL statements, to fulfill the read data operation
+     * 
+     * TODO:
+     *      - PG Service has mapReadOperationToRawReadOperation(readOperation, rawDataOperation) and returns a rawReadOperations array, so it needs to adapt to this signature
+     *      - HttpSevice has mapDataOperationToRawDataOperations(dataOperation, rawDataOperations), right structure, needs iteration on naming
+     * 
+     * There are 2 reasona why a readOperation could become multiple rawReadOperations:
+     *  1. The criteria of the read operation can't be executed in one raw Read Operation: like involving multiple queries to obtain the result
+     *  2. read operation's read expressions require multiple read operations to fullfill what's requested. Some of this can be mechanically related to the capabilities the RawDataService's endpoint, 
+     *     BUT it can also be related to the fact that a complex expression may involve other data services as well.
+     * 
+     * For which we need a way to answer the question: "Can I raw-read this expression from that type?""
+     * 
+     * ALSO - Some endpoints provide the ability to group read operations in one "group" reques
+     *   
+     * If a result is cached, rawDataOperations can receive Read[Completed|Failed]Operations as well
+     *
+     * @param {DataOperation} readOperation - The dataOperation to map
+     * @param {Array<Abstract RawReadOperation>} rawReadOperations - An array to collect the resulting raw data operations
+     * @returns {Promise<rawDataOperations>} A promise that resolves with the rawDataOperations passed in, as a convenience
+     */
+    mapReadOperationToRawReadOperations(readOperation, rawReadOperations) {
+
     }
  
 }
@@ -5273,7 +5463,10 @@ RawDataService.addClassProperties({
 
     identityQuery: {
         get: function () {
-            return this.connection.identityQuery;
+            if(!this._identityQuery) {
+                this._identityQuery = this.connection?.identityQuery
+            }
+            return this._identityQuery;
         }
     },
 

--- a/data/service/raw-data-service.js
+++ b/data/service/raw-data-service.js
@@ -1685,16 +1685,15 @@ RawDataService.addClassProperties({
                 return rawData
             } else {
                 var rawDataKeys = Object.keys(rawData),
-                    i, countI, iUpdatedRawDataValue, iCurrentRawDataValue, iDiffValues,
-                    iHasAddedValues, iHasRemovedValues,
+                    i, countI, iUpdatedRawDataValue, iCurrentRawDataValue,
+                    iHasCollectionChanges, changes,
                     canRemoveRawDataKey;
 
                 for (i = 0, countI = rawDataKeys.length; (i < countI); i++) {
 
                     iUpdatedRawDataValue = rawData[rawDataKeys[i]];
-                    iHasAddedValues = iUpdatedRawDataValue && iUpdatedRawDataValue.hasOwnProperty("addedValues");
-                    iHasRemovedValues = iUpdatedRawDataValue && iUpdatedRawDataValue.hasOwnProperty("removedValues");
-                    if (isFromUpdate && (iHasAddedValues || iHasRemovedValues)) {
+                    iHasCollectionChanges = iUpdatedRawDataValue && iUpdatedRawDataValue.hasOwnProperty("changes");
+                    if (isFromUpdate && iHasCollectionChanges) {
                         
                         canRemoveRawDataKey = true;
                         iCurrentRawDataValue = snapshot[rawDataKeys[i]];
@@ -1708,16 +1707,19 @@ RawDataService.addClassProperties({
                          * NOTE: We will eventually update DataService.handleChange to manage multiple actions on an array between saves. This 
                          * logic will need to be updated accordingly. 
                          */
-                        // if (iUpdatedRawDataValue.index !== undefined && iCurrentRawDataValue) {
+                        changes = iUpdatedRawDataValue.changes;
                         if (iCurrentRawDataValue) {
+                            
                             if (Array.isArray(iCurrentRawDataValue)) {
-                                let removeCount = iHasRemovedValues ? iUpdatedRawDataValue.removedValues.length : 0;
-                                if (iHasAddedValues) {
-                                    iCurrentRawDataValue.splice(iUpdatedRawDataValue.index, removeCount, ...iUpdatedRawDataValue.addedValues);
-                                } else {
-                                    iCurrentRawDataValue.splice(iUpdatedRawDataValue.index, removeCount);
-                                }
-                                canRemoveRawDataKey = false;
+                                let removedCount;
+                                changes.forEach(function (change) {
+                                    removedCount = change.removedValues ? change.removedValues.length : 0;
+                                    if (change.addedValues) {
+                                        iCurrentRawDataValue.splice.apply(iCurrentRawDataValue, [change.index, removedCount, ...change.addedValues]);
+                                    } else {
+                                        iCurrentRawDataValue.splice.apply(iCurrentRawDataValue, [change.index, removedCount]);
+                                    }
+                                });
                             /*
                             * TODO: 3-31-26 We need to support these, but did 
                             * not have a valid use case at the time of this writing 
@@ -1730,7 +1732,15 @@ RawDataService.addClassProperties({
                                 throw `[RawDataService] Cannot update snapshot property ${rawDataKeys[i]} without a type`;
                             }
                         } else {
-                            snapshot[rawDataKeys[i]] = iDiffValues;
+                            snapshot[rawDataKeys[i]] = iCurrentRawDataValue = [];
+                            changes.forEach(function (change) {
+                                removedCount = change.removedValues ? change.removedValues.length : 0;
+                                if (change.addedValues) {
+                                    iCurrentRawDataValue.splice.apply(iCurrentRawDataValue, [change.index, removedCount, ...change.addedValues]);
+                                } else {
+                                    iCurrentRawDataValue.splice.apply(iCurrentRawDataValue, [change.index, removedCount]);
+                                }
+                            });
                             canRemoveRawDataKey = false;
                         }
 
@@ -2584,24 +2594,24 @@ RawDataService.addClassProperties({
  * @method
  */
     _mapObjectPropertyToRawData: {
-        value: function (object, propertyName, record, context, added, removed, lastReadSnapshot, rawDataSnapshot) {
+        value: function (object, propertyName, record, context, changes, lastReadSnapshot, rawDataSnapshot) {
             var mapping = this.mappingForObject(object),
                 result;
 
             if (mapping) {
-                result = mapping.mapObjectPropertyToRawData(object, propertyName, record, context, added, removed, lastReadSnapshot, rawDataSnapshot);
+                result = mapping.mapObjectPropertyToRawData(object, propertyName, record, context, changes, lastReadSnapshot, rawDataSnapshot);
             }
 
             if (record) {
                 if (result) {
-                    var otherResult = this.mapObjectPropertyToRawData(object, propertyName, record, context, added, removed, lastReadSnapshot, rawDataSnapshot);
+                    var otherResult = this.mapObjectPropertyToRawData(object, propertyName, record, context, changes, lastReadSnapshot, rawDataSnapshot);
                     if (this._isAsync(result) && this._isAsync(otherResult)) {
                         result = Promise.all([result, otherResult]);
                     } else if (this._isAsync(otherResult)) {
                         result = otherResult;
                     }
                 } else {
-                    result = this.mapObjectPropertyToRawData(object, propertyName, record, context, added, removed, lastReadSnapshot, rawDataSnapshot);
+                    result = this.mapObjectPropertyToRawData(object, propertyName, record, context, changes, lastReadSnapshot, rawDataSnapshot);
                 }
             }
 
@@ -4370,7 +4380,7 @@ RawDataService.addClassProperties({
     },
 
 
-    __processObjectChangesForProperty: {
+    _processObjectChangesForProperty: {
         value: function (object, aProperty, aPropertyDescriptor, aPropertyChanges, operationData, lastReadSnapshot, rawDataSnapshot, rawDataPrimaryKeys, mapping) {
 
             /*
@@ -4389,7 +4399,7 @@ RawDataService.addClassProperties({
 
                 The recent addition of a DataObject property that can be a Map, we may have to re-visit that. It would be better to handle incremental changes to a map than sending all keys and all values are we doing for now
             */
-            if (aPropertyChanges && (aPropertyChanges.hasOwnProperty("addedValues") || aPropertyChanges.hasOwnProperty("removedValues"))) {
+            if (aPropertyChanges && aPropertyChanges.hasAddedOrRemovedValues) {
                 if (!(aPropertyDescriptor.cardinality > 1)) {
                     throw new Error("added/removed values for property without a to-many cardinality");
                 }
@@ -4442,26 +4452,28 @@ RawDataService.addClassProperties({
                 //     operationData[aRawProperty] = aPropertyChanges;
 
 
-                let result = this._mapObjectPropertyToRawData(object, aProperty, operationData, undefined/*context*/, aPropertyChanges.addedValues, aPropertyChanges.removedValues, lastReadSnapshot, rawDataSnapshot);
+                let result = this._mapObjectPropertyToRawData(object, aProperty, operationData, undefined/*context*/, aPropertyChanges.changes, lastReadSnapshot, rawDataSnapshot);
                 if (this._isAsync(result)) {
                     return result.then((output) => {
                         let mapping = this.mappingForObject(object),
                             rawRules = mapping.rawDataMappingRulesForObjectPropertyName(aProperty),
                             rawDataProperty;
                         
-                        if(rawRules) {
-                            var iterator = rawRules.values();
+                        // if(rawRules) {
+                        //     var iterator = rawRules.values();
 
-                            while((rule = iterator.next().value)) {
-                                rawDataProperty = rule.targetPath;
-                                if (operationData[rawDataProperty]) {
-                                    operationData[rawDataProperty].index = aPropertyChanges.index;
-                                }
-                                if (operationData[rawDataProperty] && operationData[rawDataProperty].removedValues) {
-                                    operationData[rawDataProperty].removedValues.index = aPropertyChanges.index;
-                                }
-                            }
-                        }
+                        //     while((rule = iterator.next().value)) {
+                        //         rawDataProperty = rule.targetPath;
+                        //         if (operationData[rawDataProperty]) {
+                        //             operationData[rawDataProperty].index = aPropertyChanges.index;
+                        //         }
+                        //         if (operationData[rawDataProperty] && operationData[rawDataProperty].removedValues) {
+                        //             operationData[rawDataProperty].removedValues.index = aPropertyChanges.index;
+                        //         }
+                        //     }
+                        // }
+
+                        operationData;
 
                         return output;
                     })
@@ -4569,11 +4581,11 @@ RawDataService.addClassProperties({
                     If it's a new object and somehow multiple changes led to have addedValues or removedValues, we reset that
                     so it will be processed as an new object
                 */
-                if(isNewObject && (aPropertyChanges?.hasOwnProperty("addedValues") || aPropertyChanges?.hasOwnProperty("removedValues"))) {
+                if(isNewObject && (aPropertyChanges?.hasAddedOrRemovedValues)) {
                     aPropertyChanges = null;
                 }
 
-                result = this.__processObjectChangesForProperty(object, aProperty, aPropertyDescriptor, aPropertyChanges, operationData, snapshot, dataSnapshot, rawDataPrimaryKeys, mapping);
+                result = this._processObjectChangesForProperty(object, aProperty, aPropertyDescriptor, aPropertyChanges, operationData, snapshot, dataSnapshot, rawDataPrimaryKeys, mapping);
 
                 if (result && this._isAsync(result)) {
                     (mappingPromises || (mappingPromises = [])).push(result);

--- a/data/service/raw-data-service.js
+++ b/data/service/raw-data-service.js
@@ -637,7 +637,7 @@ RawDataService.addClassProperties({
                             If this is the form toManyArray.has($), then if we have the value of toManyArray and it's null or empty, there's no way we'd find something on the other side...
                             So we can save time and return right away
                         */
-                        if((objectSnapshot[requirements[i]] === null || objectSnapshot[requirements[i]]?.length === 0) && propertyDescriptor.cardinality > 1 && rule?.converter?.convertSyntax.type === "has") {
+                        if((objectSnapshot[requirements[i]] === null || objectSnapshot[requirements[i]]?.length === 0) && propertyDescriptor.cardinality > 1 && rule?.converter?.convertSyntax?.type === "has") {
                             return Promise.resolve(null);
                         }
                         hintSnapshot[requirements[i]] = objectSnapshot[requirements[i]];

--- a/data/service/raw-data-service.js
+++ b/data/service/raw-data-service.js
@@ -1700,71 +1700,39 @@ RawDataService.addClassProperties({
                         canRemoveRawDataKey = true;
                         iCurrentRawDataValue = snapshot[rawDataKeys[i]];
 
-                        if (iHasAddedValues) {
-                            iDiffValues = iUpdatedRawDataValue.addedValues;
 
-                            if (iCurrentRawDataValue) {
-                                if (Array.isArray(iCurrentRawDataValue)) {
-                                    for (j = 0, countJ = iDiffValues.length; (j < countJ); j++) {
-                                        jDiffValue = iDiffValues[j];
-                                        /*
-                                            We shouldn't have to worry about the value already being in iCurrentRawDataValue, but we're going to safe and check
-                                        */
-                                        if (iCurrentRawDataValue.indexOf(jDiffValue) === -1) {
-                                            iCurrentRawDataValue.push(jDiffValue);
-                                            canRemoveRawDataKey = false;
-                                        }
-                                    }
+                        /**
+                         * When iUpdatedRawDataValue includes an index, we can assume the change was a result of a single action on the array 
+                         * assignment, push, splice, etc. If that is the case, we can avoid special logic and use splice to add the new 
+                         * values and remove the old. 
+                         * 
+                         * NOTE: We will eventually update DataService.handleChange to manage multiple actions on an array between saves. This 
+                         * logic will need to be updated accordingly. 
+                         */
+                        // if (iUpdatedRawDataValue.index !== undefined && iCurrentRawDataValue) {
+                        if (iCurrentRawDataValue) {
+                            if (Array.isArray(iCurrentRawDataValue)) {
+                                let removeCount = iHasRemovedValues ? iUpdatedRawDataValue.removedValues.length : 0;
+                                if (iHasAddedValues) {
+                                    iCurrentRawDataValue.splice(iUpdatedRawDataValue.index, removeCount, ...iUpdatedRawDataValue.addedValues);
                                 } else {
-                                    console.warn("recordSnapshot when one exists: snapshot for '" + rawDataKeys[i] + "' is not an Array but addedValues is:", iDiffValues);
-                                    /* there's a current value that is not an array.. Which is weird... */
-                                    snapshot[rawDataKeys[i]] = iDiffValues;
-                                    canRemoveRawDataKey = false;
+                                    iCurrentRawDataValue.splice(iUpdatedRawDataValue.index, removeCount);
                                 }
-                            } else {
-                                //console.warn("recordSnapshot from Update: No entry in snapshot for '" + rawDataKeys[i] + "' but addedValues:", iDiffValues);
-                                /*
-                                    We could reconstruct from the object value, but we should really not be here.
-                                */
-                                snapshot[rawDataKeys[i]] = iDiffValues;
                                 canRemoveRawDataKey = false;
-                            }
-                        }
-
-                        if (iHasRemovedValues) {
-                            iDiffValues = iUpdatedRawDataValue.removedValues;
-
-                            /* 
-                                WARNING
-                                iCurrentRawDataValue was cached early in the loop and there's a use-case where 
-                                iCurrentRawDataValue would not be equal to rawData[rawDataKeys[i]] because
-                                it might have changed in the block above, which is when there was no value at all.
-
-                                So the only use case where not refreshing it would be if somehow the data service
-                                received a value in .addedValues array that is also in the .removedValues, which would 
-                                be strange
+                            /*
+                            * TODO: 3-31-26 We need to support these, but did 
+                            * not have a valid use case at the time of this writing 
                             */
-
-                            if (iCurrentRawDataValue) {
-                                if (Array.isArray(iCurrentRawDataValue)) {
-                                    for (j = 0, countJ = iDiffValues.length; (j < countJ); j++) {
-                                        jDiffValue = iDiffValues[j];
-                                        /*
-                                            We shouldn't have to worry about the value alredy being in iCurrentRawDataValue, but we're going to safe and check
-                                        */
-                                        if ((jDiffValueIndex = iCurrentRawDataValue.indexOf(jDiffValue)) !== -1) {
-                                            iCurrentRawDataValue.splice(jDiffValueIndex, 1);
-                                            canRemoveRawDataKey = false;
-                                        }
-                                    }
-                                } else {
-                                    console.warn("recordSnapshot from Update: snapshot for '" + rawDataKeys[i] + "' is not an Array but removedValues:", iDiffValues);
-                                    console.error("removedValues but no entry in snapshot for ")
-                                    //snapshot[rawDataKeys[i]] = iDiffValues;
-                                }
+                            } else if (iCurrentRawDataValue instanceof Map) {
+                                throw `[RawDataService] Cannot update snapshot property ${rawDataKeys[i]} of type Map`;
+                            } else if (iCurrentRawDataValue instanceof Set) {
+                                throw `[RawDataService] Cannot update snapshot property ${rawDataKeys[i]} of type Set`;
                             } else {
-                                console.warn("recordSnapshot from Update: No entry in snapshot for '" + rawDataKeys[i] + "' but removedValues:", iDiffValues);
+                                throw `[RawDataService] Cannot update snapshot property ${rawDataKeys[i]} without a type`;
                             }
+                        } else {
+                            snapshot[rawDataKeys[i]] = iDiffValues;
+                            canRemoveRawDataKey = false;
                         }
 
                         if(canRemoveRawDataKey) {

--- a/data/service/serialized-data-service.mod/serialized-data-service.js
+++ b/data/service/serialized-data-service.mod/serialized-data-service.js
@@ -471,7 +471,9 @@ exports.SerializedDataService = class SerializedDataService extends RawDataServi
         // TODO: Temporary workaround — until RawDataService can lazily subscribe to incoming
         // data operations, verify here whether this service should handle the operation.
 
-        if (!this.handlesType(readOperation.target)) return;
+        if (!this.handlesType(readOperation.target)) {
+            return;
+        }
 
         //TJ If there is no delegate, callDelegateMethod returns null which throws an error. Do we need a null check or should we ALWAYS have a delegate?
         let delegatePromise = this.callDelegateMethod("rawDataServiceWillHandleReadOperation", this, readOperation) || Promise.resolve(readOperation);

--- a/data/service/serialized-data-service.mod/serialized-data-service.js
+++ b/data/service/serialized-data-service.mod/serialized-data-service.js
@@ -327,7 +327,7 @@ exports.SerializedDataService = class SerializedDataService extends RawDataServi
         }
 
         if(this.needsRawDataTypeIdentificationCriteria) {
-            let criteria = this.defaultOwnRawDataTypeIdentificationCriteriaForObjectDescriptor(object.objectDescriptor);
+            let criteria = this.rawDataTypeIdentificationCriteriaForType(object.objectDescriptor);
             assign(rawData, criteria.expression, true, criteria.parameters);
         }
     }

--- a/data/service/web-socket-data-operation-service.js
+++ b/data/service/web-socket-data-operation-service.js
@@ -883,6 +883,36 @@ WebSocketDataOperationService.addClassProperties({
                 //Overrides operation's needsDataMapping to get started
                 operation.needsDataMapping = true;
 
+
+                //TODO: Move to RawDataService
+                //Add check for Types that are stored with subtypes, to make sure that if there are readExpressions, it contains the property needed to tell them apart:
+                if (this.mappingForType(operation.target).needsRawDataTypeIdentificationCriteria) {
+                    let criteria = this.rawDataTypeIdentificationCriteriaForType(operation.target),
+                        properties = criteria.qualifiedProperties;
+
+                    if(properties.length > 0) {
+                        let operationReadExpressions = operation.data.readExpressions;
+
+                        /*
+                            if there are no readExpressions in the operation, all properties are expected to be returned,
+                            which has to include the one(s) needed to tell subtypes from each others.
+
+                            So only if there are readExpressions in the operation. we make sure it includes those needed properties
+                        */
+                        if(operationReadExpressions) {
+                            for(let i=0, countI = properties.length; (i<countI); i++) {
+                                if(!properties.includes(properties[i])) {
+                                    properties.push(properties[i]);
+                                }
+                            }
+                        }
+
+                    } else {
+                        console.warn(`Mapping Inconsistency: ${operation.target.name} needs RawData Type Identification Criteria but criteria's qualifiedProperties is empty`);
+                    }
+
+                }
+
                 if (this._readOperationQueue.length === 1) {
                     queueMicrotask(() => {
                     //this._processOperationQueueTimeout = setTimeout(() => {

--- a/test/spec/ui/visual-style-spec.js
+++ b/test/spec/ui/visual-style-spec.js
@@ -44,8 +44,8 @@ describe("test/ui/visual-style-spec", function () {
             expect(visualStyle.controlFocusFill.fallback).toBe(visualStyle.controlActiveFill);
 
             expect(visualStyle.textFill.fallback).toBe(undefined);
-            expect(visualStyle.textSecondaryFill.fallback).toBe(visualStyle.textFill);
-            expect(visualStyle.tertiaryTextFill.fallback).toBe(visualStyle.textSecondaryFill);
+            expect(visualStyle.secondaryTextFill.fallback).toBe(visualStyle.textFill);
+            expect(visualStyle.tertiaryTextFill.fallback).toBe(visualStyle.secondaryTextFill);
             expect(visualStyle.quaternaryTextFill.fallback).toBe(visualStyle.tertiaryTextFill);
 
             expect(visualStyle.linkTextFill.fallback).toBe(visualStyle.textFill);
@@ -148,7 +148,7 @@ describe("test/ui/visual-style-spec", function () {
             visualStyle.controlSelectionBackgroundFill.value = "#0D0";
             visualStyle.controlActiveFill.value = "#0FF";
             visualStyle.textFill.value = "#484";
-            visualStyle.textSecondaryFill.value = "#666";
+            visualStyle.secondaryTextFill.value = "#666";
             visualStyle.tertiaryTextFill.value = "#777";
             visualStyle.quaternaryTextFill.value = "#777";
 

--- a/test/spec/ui/visual-style-spec.js
+++ b/test/spec/ui/visual-style-spec.js
@@ -45,8 +45,8 @@ describe("test/ui/visual-style-spec", function () {
 
             expect(visualStyle.textFill.fallback).toBe(undefined);
             expect(visualStyle.textSecondaryFill.fallback).toBe(visualStyle.textFill);
-            expect(visualStyle.textTertiaryFill.fallback).toBe(visualStyle.textSecondaryFill);
-            expect(visualStyle.textQuaternaryFill.fallback).toBe(visualStyle.textTertiaryFill);
+            expect(visualStyle.tertiaryTextFill.fallback).toBe(visualStyle.textSecondaryFill);
+            expect(visualStyle.quaternaryTextFill.fallback).toBe(visualStyle.tertiaryTextFill);
 
             expect(visualStyle.linkTextFill.fallback).toBe(visualStyle.textFill);
         });
@@ -91,9 +91,9 @@ describe("test/ui/visual-style-spec", function () {
              --visual-style-control-height: 36px;
             --visual-style-text-fill: hsla(0, 0%, 0%, .7);
             --visual-style-text-secondary-fill: hsla(0, 0%, 0%, .7);
-            --visual-style-text-tertiary-fill: hsla(0, 0%, 0%, .7);
+            --visual-style-tertiary-text-fill: hsla(0, 0%, 0%, .7);
             --visual-style-text-quaternary-fill: hsla(0, 0%, 0%, .7);
-            --visual-style-text-error-fill: hsla(0, 0%, 0%, .7);
+            --visual-style-error-text-fill: hsla(0, 0%, 0%, .7);
             --visual-style-text-size: 12px;
             --visual-style-link-text-fill: hsla(0, 0%, 0%, .7);
             }
@@ -131,9 +131,9 @@ describe("test/ui/visual-style-spec", function () {
             --visual-style-control-height: 36px;
             --visual-style-text-fill: #484;
             --visual-style-text-secondary-fill: #666;
-            --visual-style-text-tertiary-fill: #777;
+            --visual-style-tertiary-text-fill: #777;
             --visual-style-text-quaternary-fill: #777;
-            --visual-style-text-error-fill: #484;
+            --visual-style-error-text-fill: #484;
             --visual-style-text-size: 12px;
             --visual-style-link-text-fill: #484;
             }
@@ -149,8 +149,8 @@ describe("test/ui/visual-style-spec", function () {
             visualStyle.controlActiveFill.value = "#0FF";
             visualStyle.textFill.value = "#484";
             visualStyle.textSecondaryFill.value = "#666";
-            visualStyle.textTertiaryFill.value = "#777";
-            visualStyle.textQuaternaryFill.value = "#777";
+            visualStyle.tertiaryTextFill.value = "#777";
+            visualStyle.quaternaryTextFill.value = "#777";
 
             expect(visualStyle.generateCSS(true)).toEqual(expectedOutput);
         })
@@ -183,9 +183,9 @@ describe("test/ui/visual-style-spec", function () {
             --visual-style-control-height: 36px;
             --visual-style-text-fill: #222;
             --visual-style-text-secondary-fill: #222;
-            --visual-style-text-tertiary-fill: #222;
+            --visual-style-tertiary-text-fill: #222;
             --visual-style-text-quaternary-fill: #222;
-            --visual-style-text-error-fill: #222;
+            --visual-style-error-text-fill: #222;
             --visual-style-text-size: 12px;
             --visual-style-link-text-fill: #222;
         }

--- a/ui/control.js
+++ b/ui/control.js
@@ -431,9 +431,11 @@ Control.addClassProperties(
     takeValueFromElement: {
         value: function(isFromInput) {
             //console.log(this.identifier+".takeValueFromElement - this.elementValue is "+this.elementValue);
-            isFromInput
-                ? Object.getPropertyDescriptor(this, "value").set.call(this, this.elementValue, true)
-                : this.value = this.elementValue;
+            if(this.elementValue !== "") {
+                isFromInput
+                    ? Object.getPropertyDescriptor(this, "value").set.call(this, this.elementValue, true)
+                    : this.value = this.elementValue;
+            }
         }
     },
     /**

--- a/ui/property-field.mod/property-field.css
+++ b/ui/property-field.mod/property-field.css
@@ -20,7 +20,7 @@
 }
 
 .ModPropertyField-error {
-    color: var(--visual-style-text-error-fill);
+    color: var(--visual-style-error-text-fill);
 }
 
 .ModPropertyField-helpButton {

--- a/ui/property-field.mod/teach/ui/main.mod/main.html
+++ b/ui/property-field.mod/teach/ui/main.mod/main.html
@@ -14,7 +14,7 @@
                 "visualStyle": {
                     "prototype": "mod/ui/visual-style.mod",
                     "values": {
-                        "textErrorFill": "#f00",
+                        "errorTextFill": "#f00",
                         "controlBackgroundFill": "#eee"
                     }
                 },

--- a/ui/select.mod/select.js
+++ b/ui/select.mod/select.js
@@ -576,7 +576,7 @@ exports.Select = class Select extends Control {
 
 //http://www.w3.org/TR/html5/the-button-element.html#the-select-element
 
-Select.addAttributes(
+exports.Select.addAttributes(
     /** @lends module:"mod/ui/native/select.mod".Select */ {
         /**
     Specifies whether the element should be focused as soon as the page is loaded.

--- a/ui/visual-style.mod/visual-style.js
+++ b/ui/visual-style.mod/visual-style.js
@@ -68,7 +68,7 @@ var PROPERTIES = [
 
     {name: "textFill", variable: "--visual-style-text-fill", defaultValue: "hsla(0, 0%, 0%, .7)"},
     {name: "secondaryTextFill", variable: "--visual-style-secondary-text-fill", backup: "textFill"},
-    {name: "tertiaryTextFill", variable: "--visual-style-tertiary-text-fill", backup: "textSecondaryFill"},
+    {name: "tertiaryTextFill", variable: "--visual-style-tertiary-text-fill", backup: "secondaryTextFill"},
     {name: "quaternaryTextFill", variable: "--visual-style-text-quaternary-fill", backup: "tertiaryTextFill"},
 
     {name: "errorTextFill", variable: "--visual-style-error-text-fill", backup: "textFill"},
@@ -195,7 +195,7 @@ exports.VisualStyle = class VisualStyle extends Montage {
         this._deserializeProperty(deserializer, "controlSelectionBackgroundFill");
         this._deserializeProperty(deserializer, "controlHeight");
         this._deserializeProperty(deserializer, "textFill");
-        this._deserializeProperty(deserializer, "textSecondaryFill");
+        this._deserializeProperty(deserializer, "secondaryTextFill");
         this._deserializeProperty(deserializer, "tertiaryTextFill");
         this._deserializeProperty(deserializer, "quaternaryTextFill");
         this._deserializeProperty(deserializer, "errorTextFill");

--- a/ui/visual-style.mod/visual-style.js
+++ b/ui/visual-style.mod/visual-style.js
@@ -67,11 +67,11 @@ var PROPERTIES = [
     {name: "controlHeight", variable: "--visual-style-control-height", defaultValue: "36px"},
 
     {name: "textFill", variable: "--visual-style-text-fill", defaultValue: "hsla(0, 0%, 0%, .7)"},
-    {name: "textSecondaryFill", variable: "--visual-style-text-secondary-fill", backup: "textFill"},
-    {name: "textTertiaryFill", variable: "--visual-style-text-tertiary-fill", backup: "textSecondaryFill"},
-    {name: "textQuaternaryFill", variable: "--visual-style-text-quaternary-fill", backup: "textTertiaryFill"},
+    {name: "secondaryTextFill", variable: "--visual-style-secondary-text-fill", backup: "textFill"},
+    {name: "tertiaryTextFill", variable: "--visual-style-tertiary-text-fill", backup: "textSecondaryFill"},
+    {name: "quaternaryTextFill", variable: "--visual-style-text-quaternary-fill", backup: "tertiaryTextFill"},
 
-    {name: "textErrorFill", variable: "--visual-style-text-error-fill", backup: "textFill"},
+    {name: "errorTextFill", variable: "--visual-style-error-text-fill", backup: "textFill"},
 
     {name: "textSize", variable: "--visual-style-text-size", defaultValue: "12px"},
 
@@ -196,9 +196,9 @@ exports.VisualStyle = class VisualStyle extends Montage {
         this._deserializeProperty(deserializer, "controlHeight");
         this._deserializeProperty(deserializer, "textFill");
         this._deserializeProperty(deserializer, "textSecondaryFill");
-        this._deserializeProperty(deserializer, "textTertiaryFill");
-        this._deserializeProperty(deserializer, "textQuaternaryFill");
-        this._deserializeProperty(deserializer, "textErrorFill");
+        this._deserializeProperty(deserializer, "tertiaryTextFill");
+        this._deserializeProperty(deserializer, "quaternaryTextFill");
+        this._deserializeProperty(deserializer, "errorTextFill");
         this._deserializeProperty(deserializer, "textSize");
         this._deserializeProperty(deserializer, "linkTextFill");
     }


### PR DESCRIPTION
- fix lost array changes if multiple are cumulated before a save happens
- fix instantiation as superclass instead of the right subclass in some cases
- fix refetch overriding local changes when refetched values are identical to snapshot
- fix a regression in frb
- introduce ability on DataQuery to ask for a refresh of instance's property values - refreshesRefetchedInstances
- add isEmpty property to Array.prototype
- add allKeys() method to Object.prototype
- add Uuid.noValue - '00000000-0000-0000-0000-000000000000'
- add saving of null relationships as Uuid.noValue, leaving NULL in PG as really meaning undefined in those cases
- fix a bug with change events that caused confusion between DOM change and Mod's (property) change
- avoid considering adding undefined to a data object property array as a change
- more fixes/cleanup to Trigger's _getValue / _setValue
- fix a few VisualStyle text-related properties' name